### PR TITLE
Add REST API endpoints for sources and imports

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -9,6 +9,8 @@ namespace AI_Importer;
 
 use AI_Importer\Adapters\AdapterRegistry;
 use AI_Importer\Processor\ImportProcessor;
+use AI_Importer\REST\ImportsController;
+use AI_Importer\REST\SourcesController;
 
 /**
  * Plugin class.
@@ -94,7 +96,11 @@ class Plugin {
 	 * @return void
 	 */
 	public function register_rest_routes(): void {
-		// REST routes will be added in future issues.
+		$sources_controller = new SourcesController();
+		$sources_controller->register_routes();
+
+		$imports_controller = new ImportsController();
+		$imports_controller->register_routes();
 	}
 
 	/**

--- a/includes/REST/ImportsController.php
+++ b/includes/REST/ImportsController.php
@@ -1,0 +1,471 @@
+<?php
+/**
+ * REST controller for import batches.
+ *
+ * @package AI_Importer
+ */
+
+namespace AI_Importer\REST;
+
+use AI_Importer\Adapters\AdapterRegistry;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Handles REST API endpoints for managing import batches.
+ *
+ * Batch data is stored in wp_options as ai_importer_batch_{uuid}.
+ *
+ * Endpoints:
+ *   POST   /imports                      - Start a new import batch
+ *   GET    /imports                       - List import batches
+ *   GET    /imports/{batch_id}            - Get batch progress
+ *   POST   /imports/{batch_id}/pause      - Pause a batch
+ *   POST   /imports/{batch_id}/resume     - Resume a batch
+ *   DELETE /imports/{batch_id}            - Rollback a batch
+ */
+class ImportsController extends WP_REST_Controller {
+
+	/**
+	 * Route namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'ai-importer/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'imports';
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'limit' => array(
+							'type'              => 'integer',
+							'default'           => 10,
+							'minimum'           => 1,
+							'maximum'           => 100,
+							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'source_adapter' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'item_ids'       => array(
+							'required' => true,
+							'type'     => 'array',
+							'items'    => array( 'type' => 'string' ),
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<batch_id>[a-f0-9-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_batch_id_args(),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_batch_id_args(),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<batch_id>[a-f0-9-]+)/pause',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'pause_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_batch_id_args(),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<batch_id>[a-f0-9-]+)/resume',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'resume_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => $this->get_batch_id_args(),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check if the current user can manage imports.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check( $request ): bool|WP_Error {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage imports.', 'ai-importer' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * List import batches.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$limit     = $request->get_param( 'limit' );
+		$batch_ids = get_option( 'ai_importer_batch_index', array() );
+
+		// Sort newest first.
+		$batch_ids = array_reverse( $batch_ids );
+		$batch_ids = array_slice( $batch_ids, 0, $limit );
+
+		$batches = array();
+
+		foreach ( $batch_ids as $batch_id ) {
+			$batch = $this->get_batch( $batch_id );
+
+			if ( $batch ) {
+				$batches[] = $this->serialize_batch( $batch );
+			}
+		}
+
+		return rest_ensure_response( $batches );
+	}
+
+	/**
+	 * Get a single import batch.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ): WP_REST_Response|WP_Error {
+		$batch = $this->get_batch( $request['batch_id'] );
+
+		if ( ! $batch ) {
+			return $this->batch_not_found_error();
+		}
+
+		return rest_ensure_response( $this->serialize_batch( $batch ) );
+	}
+
+	/**
+	 * Create a new import batch.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ): WP_REST_Response|WP_Error {
+		$source_adapter = $request->get_param( 'source_adapter' );
+		$item_ids       = $request->get_param( 'item_ids' );
+
+		// Validate the adapter exists and is authenticated.
+		$registry = AdapterRegistry::get_instance();
+		$adapter  = $registry->get( $source_adapter );
+
+		if ( ! $adapter ) {
+			return new WP_Error(
+				'invalid_source',
+				__( 'Source adapter not found.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! $adapter->is_authenticated() ) {
+			return new WP_Error(
+				'not_authenticated',
+				__( 'Source adapter is not connected.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( empty( $item_ids ) ) {
+			return new WP_Error(
+				'empty_items',
+				__( 'No items selected for import.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$batch_id = wp_generate_uuid4();
+		$now      = gmdate( 'c' );
+
+		$batch = array(
+			'id'             => $batch_id,
+			'source_adapter' => $source_adapter,
+			'state'          => 'processing',
+			'item_ids'       => $item_ids,
+			'total'          => count( $item_ids ),
+			'processed'      => 0,
+			'failed'         => 0,
+			'errors'         => array(),
+			'created_at'     => $now,
+			'started_at'     => $now,
+			'completed_at'   => null,
+			'imported_ids'   => array(),
+		);
+
+		$this->save_batch( $batch );
+		$this->add_to_batch_index( $batch_id );
+
+		/**
+		 * Fires when a new import batch is created.
+		 *
+		 * The import processor should hook into this action to begin
+		 * processing the batch (e.g., schedule Action Scheduler jobs).
+		 *
+		 * @param string               $batch_id The batch UUID.
+		 * @param array<string, mixed> $batch    The batch data.
+		 */
+		do_action( 'ai_importer_batch_created', $batch_id, $batch );
+
+		return new WP_REST_Response( $this->serialize_batch( $batch ), 201 );
+	}
+
+	/**
+	 * Pause a running import batch.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function pause_item( $request ): WP_REST_Response|WP_Error {
+		$batch = $this->get_batch( $request['batch_id'] );
+
+		if ( ! $batch ) {
+			return $this->batch_not_found_error();
+		}
+
+		if ( 'processing' !== $batch['state'] ) {
+			return new WP_Error(
+				'invalid_state',
+				__( 'Only processing imports can be paused.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$batch['state'] = 'paused';
+		$this->save_batch( $batch );
+
+		/**
+		 * Fires when an import batch is paused.
+		 *
+		 * @param string               $batch_id The batch UUID.
+		 * @param array<string, mixed> $batch    The batch data.
+		 */
+		do_action( 'ai_importer_batch_paused', $request['batch_id'], $batch );
+
+		return rest_ensure_response( $this->serialize_batch( $batch ) );
+	}
+
+	/**
+	 * Resume a paused import batch.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function resume_item( $request ): WP_REST_Response|WP_Error {
+		$batch = $this->get_batch( $request['batch_id'] );
+
+		if ( ! $batch ) {
+			return $this->batch_not_found_error();
+		}
+
+		if ( 'paused' !== $batch['state'] ) {
+			return new WP_Error(
+				'invalid_state',
+				__( 'Only paused imports can be resumed.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$batch['state'] = 'processing';
+		$this->save_batch( $batch );
+
+		/**
+		 * Fires when an import batch is resumed.
+		 *
+		 * @param string               $batch_id The batch UUID.
+		 * @param array<string, mixed> $batch    The batch data.
+		 */
+		do_action( 'ai_importer_batch_resumed', $request['batch_id'], $batch );
+
+		return rest_ensure_response( $this->serialize_batch( $batch ) );
+	}
+
+	/**
+	 * Rollback (delete) an import batch and its imported content.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ): WP_REST_Response|WP_Error {
+		$batch = $this->get_batch( $request['batch_id'] );
+
+		if ( ! $batch ) {
+			return $this->batch_not_found_error();
+		}
+
+		// Delete any imported posts.
+		if ( ! empty( $batch['imported_ids'] ) ) {
+			foreach ( $batch['imported_ids'] as $post_id ) {
+				wp_delete_post( (int) $post_id, true );
+			}
+		}
+
+		$batch['state']        = 'rolled_back';
+		$batch['completed_at'] = gmdate( 'c' );
+		$this->save_batch( $batch );
+
+		/**
+		 * Fires when an import batch is rolled back.
+		 *
+		 * @param string               $batch_id The batch UUID.
+		 * @param array<string, mixed> $batch    The batch data.
+		 */
+		do_action( 'ai_importer_batch_rolled_back', $request['batch_id'], $batch );
+
+		return rest_ensure_response( $this->serialize_batch( $batch ) );
+	}
+
+	/**
+	 * Get batch data from the database.
+	 *
+	 * @param string $batch_id Batch UUID.
+	 * @return array<string, mixed>|false Batch data or false.
+	 */
+	private function get_batch( string $batch_id ) {
+		return get_option( 'ai_importer_batch_' . $batch_id, false );
+	}
+
+	/**
+	 * Save batch data to the database.
+	 *
+	 * @param array<string, mixed> $batch Batch data (must include 'id').
+	 * @return bool
+	 */
+	private function save_batch( array $batch ): bool {
+		return update_option( 'ai_importer_batch_' . $batch['id'], $batch, false );
+	}
+
+	/**
+	 * Add a batch ID to the index of all batches.
+	 *
+	 * @param string $batch_id Batch UUID.
+	 * @return void
+	 */
+	private function add_to_batch_index( string $batch_id ): void {
+		$index   = get_option( 'ai_importer_batch_index', array() );
+		$index[] = $batch_id;
+		update_option( 'ai_importer_batch_index', $index, false );
+	}
+
+	/**
+	 * Serialize a batch for API response.
+	 *
+	 * Produces the shape expected by the frontend ImportProgress component.
+	 *
+	 * @param array<string, mixed> $batch Raw batch data.
+	 * @return array<string, mixed>
+	 */
+	private function serialize_batch( array $batch ): array {
+		$total      = max( 1, (int) $batch['total'] );
+		$processed  = (int) $batch['processed'];
+		$percentage = min( 100, (int) round( ( $processed / $total ) * 100 ) );
+
+		$state_labels = array(
+			'processing'  => __( 'Processing', 'ai-importer' ),
+			'paused'      => __( 'Paused', 'ai-importer' ),
+			'completed'   => __( 'Completed', 'ai-importer' ),
+			'failed'      => __( 'Failed', 'ai-importer' ),
+			'rolled_back' => __( 'Rolled Back', 'ai-importer' ),
+		);
+
+		return array(
+			'id'             => $batch['id'],
+			'source_adapter' => $batch['source_adapter'],
+			'state'          => $batch['state'],
+			'state_label'    => $state_labels[ $batch['state'] ] ?? $batch['state'],
+			'total'          => $total,
+			'processed'      => $processed,
+			'failed'         => (int) $batch['failed'],
+			'percentage'     => $percentage,
+			'created_at'     => $batch['created_at'],
+			'started_at'     => $batch['started_at'] ?? null,
+			'completed_at'   => $batch['completed_at'] ?? null,
+			'errors'         => array_slice( $batch['errors'] ?? array(), -50 ),
+		);
+	}
+
+	/**
+	 * Get common batch_id route arguments.
+	 *
+	 * @return array<string, array<string, mixed>>
+	 */
+	private function get_batch_id_args(): array {
+		return array(
+			'batch_id' => array(
+				'required'          => true,
+				'type'              => 'string',
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+	}
+
+	/**
+	 * Return a standard "batch not found" error.
+	 *
+	 * @return WP_Error
+	 */
+	private function batch_not_found_error(): WP_Error {
+		return new WP_Error(
+			'batch_not_found',
+			__( 'Import batch not found.', 'ai-importer' ),
+			array( 'status' => 404 )
+		);
+	}
+}

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -218,7 +218,8 @@ class SourcesController extends WP_REST_Controller {
 			return $adapter;
 		}
 
-		$credentials = array();
+		$credentials   = array();
+		$uploaded_file = null;
 
 		// Handle file uploads.
 		$files = $request->get_file_params();
@@ -230,6 +231,7 @@ class SourcesController extends WP_REST_Controller {
 				return $upload;
 			}
 
+			$uploaded_file       = $upload;
 			$credentials['file'] = $upload;
 		}
 
@@ -250,6 +252,11 @@ class SourcesController extends WP_REST_Controller {
 		$success = $adapter->authenticate( $credentials );
 
 		if ( ! $success ) {
+			// Clean up the uploaded file to avoid orphaned archives.
+			if ( $uploaded_file && file_exists( $uploaded_file ) ) {
+				wp_delete_file( $uploaded_file );
+			}
+
 			return new WP_Error(
 				'authentication_failed',
 				__( 'Failed to connect to the source. Please check your credentials and try again.', 'ai-importer' ),
@@ -392,12 +399,17 @@ class SourcesController extends WP_REST_Controller {
 		$upload_dir = wp_upload_dir();
 		$dest_dir   = $upload_dir['basedir'] . '/ai-importer-tmp';
 
-		if ( ! file_exists( $dest_dir ) && ! wp_mkdir_p( $dest_dir ) ) {
-			return new WP_Error(
-				'upload_error',
-				__( 'Failed to create upload directory.', 'ai-importer' ),
-				array( 'status' => 500 )
-			);
+		if ( ! file_exists( $dest_dir ) ) {
+			if ( ! wp_mkdir_p( $dest_dir ) ) {
+				return new WP_Error(
+					'upload_error',
+					__( 'Failed to create upload directory.', 'ai-importer' ),
+					array( 'status' => 500 )
+				);
+			}
+
+			// Protect the directory from direct web access.
+			$this->protect_directory( $dest_dir );
 		}
 
 		$filename = wp_unique_filename( $dest_dir, sanitize_file_name( $file['name'] ) );
@@ -413,5 +425,32 @@ class SourcesController extends WP_REST_Controller {
 		}
 
 		return $dest;
+	}
+
+	/**
+	 * Protect a directory from direct web access.
+	 *
+	 * Creates .htaccess (Apache) and index.php files to prevent
+	 * directory listing and direct file access.
+	 *
+	 * @param string $dir Directory path.
+	 * @return void
+	 */
+	private function protect_directory( string $dir ): void {
+		// Apache: deny all direct access.
+		$htaccess = $dir . '/.htaccess';
+
+		if ( ! file_exists( $htaccess ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writing server config, not content.
+			file_put_contents( $htaccess, "Deny from all\n" );
+		}
+
+		// Fallback: empty index.php to prevent directory listing.
+		$index = $dir . '/index.php';
+
+		if ( ! file_exists( $index ) ) {
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Writing server config, not content.
+			file_put_contents( $index, "<?php\n// Silence is golden.\n" );
+		}
 	}
 }

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -221,7 +221,21 @@ class SourcesController extends WP_REST_Controller {
 		$credentials   = array();
 		$uploaded_file = null;
 
-		// Handle file uploads.
+		// Merge body and JSON params first.
+		$body_params = $request->get_body_params();
+
+		if ( ! empty( $body_params ) ) {
+			$credentials = array_merge( $credentials, $body_params );
+		}
+
+		$json_params = $request->get_json_params();
+
+		if ( ! empty( $json_params ) ) {
+			$credentials = array_merge( $credentials, $json_params );
+		}
+
+		// Handle file uploads last so the trusted path cannot be
+		// overwritten by user-supplied body/JSON params.
 		$files = $request->get_file_params();
 
 		if ( ! empty( $files['file'] ) ) {
@@ -233,20 +247,6 @@ class SourcesController extends WP_REST_Controller {
 
 			$uploaded_file       = $upload;
 			$credentials['file'] = $upload;
-		}
-
-		// Merge any additional body params as credentials.
-		$body_params = $request->get_body_params();
-
-		if ( ! empty( $body_params ) ) {
-			$credentials = array_merge( $credentials, $body_params );
-		}
-
-		// Also check JSON body.
-		$json_params = $request->get_json_params();
-
-		if ( ! empty( $json_params ) ) {
-			$credentials = array_merge( $credentials, $json_params );
 		}
 
 		$success = $adapter->authenticate( $credentials );
@@ -399,18 +399,16 @@ class SourcesController extends WP_REST_Controller {
 		$upload_dir = wp_upload_dir();
 		$dest_dir   = $upload_dir['basedir'] . '/ai-importer-tmp';
 
-		if ( ! file_exists( $dest_dir ) ) {
-			if ( ! wp_mkdir_p( $dest_dir ) ) {
-				return new WP_Error(
-					'upload_error',
-					__( 'Failed to create upload directory.', 'ai-importer' ),
-					array( 'status' => 500 )
-				);
-			}
-
-			// Protect the directory from direct web access.
-			$this->protect_directory( $dest_dir );
+		if ( ! file_exists( $dest_dir ) && ! wp_mkdir_p( $dest_dir ) ) {
+			return new WP_Error(
+				'upload_error',
+				__( 'Failed to create upload directory.', 'ai-importer' ),
+				array( 'status' => 500 )
+			);
 		}
+
+		// Ensure the directory is protected from direct web access.
+		$this->protect_directory( $dest_dir );
 
 		$filename = wp_unique_filename( $dest_dir, sanitize_file_name( $file['name'] ) );
 		$dest     = $dest_dir . '/' . $filename;

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -392,8 +392,12 @@ class SourcesController extends WP_REST_Controller {
 		$upload_dir = wp_upload_dir();
 		$dest_dir   = $upload_dir['basedir'] . '/ai-importer-tmp';
 
-		if ( ! file_exists( $dest_dir ) ) {
-			wp_mkdir_p( $dest_dir );
+		if ( ! file_exists( $dest_dir ) && ! wp_mkdir_p( $dest_dir ) ) {
+			return new WP_Error(
+				'upload_error',
+				__( 'Failed to create upload directory.', 'ai-importer' ),
+				array( 'status' => 500 )
+			);
 		}
 
 		$filename = wp_unique_filename( $dest_dir, sanitize_file_name( $file['name'] ) );

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -1,0 +1,413 @@
+<?php
+/**
+ * REST controller for source adapters.
+ *
+ * @package AI_Importer
+ */
+
+namespace AI_Importer\REST;
+
+use AI_Importer\Adapters\AdapterRegistry;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Handles REST API endpoints for managing source adapters.
+ *
+ * Endpoints:
+ *   GET    /sources                     - List all adapters
+ *   GET    /sources/{id}                - Get adapter details with schema
+ *   POST   /sources/{id}/connect        - Authenticate an adapter
+ *   POST   /sources/{id}/disconnect     - Disconnect an adapter
+ *   GET    /sources/{id}/manifest       - Fetch content manifest
+ */
+class SourcesController extends WP_REST_Controller {
+
+	/**
+	 * Route namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'ai-importer/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'sources';
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/connect',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'connect_source' ),
+					'permission_callback' => array( $this, 'manage_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/disconnect',
+			array(
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'disconnect_source' ),
+					'permission_callback' => array( $this, 'manage_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/manifest',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_manifest' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check if the current user can read sources.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function get_items_permissions_check( $request ): bool|WP_Error {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to access sources.', 'ai-importer' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if the current user can manage sources.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function manage_permissions_check( $request ): bool|WP_Error {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage sources.', 'ai-importer' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * List all available source adapters.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$registry = AdapterRegistry::get_instance();
+		$adapters = $registry->to_array();
+
+		return rest_ensure_response( array_values( $adapters ) );
+	}
+
+	/**
+	 * Get a single source adapter with settings schema.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_item( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		$data                    = $this->serialize_adapter( $adapter );
+		$data['settings_schema'] = $adapter->get_settings_schema()->to_array();
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Connect (authenticate) a source adapter.
+	 *
+	 * Handles both JSON credentials and multipart file uploads.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function connect_source( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		$credentials = array();
+
+		// Handle file uploads.
+		$files = $request->get_file_params();
+
+		if ( ! empty( $files['file'] ) ) {
+			$upload = $this->handle_file_upload( $files['file'] );
+
+			if ( is_wp_error( $upload ) ) {
+				return $upload;
+			}
+
+			$credentials['file'] = $upload;
+		}
+
+		// Merge any additional body params as credentials.
+		$body_params = $request->get_body_params();
+
+		if ( ! empty( $body_params ) ) {
+			$credentials = array_merge( $credentials, $body_params );
+		}
+
+		// Also check JSON body.
+		$json_params = $request->get_json_params();
+
+		if ( ! empty( $json_params ) ) {
+			$credentials = array_merge( $credentials, $json_params );
+		}
+
+		$success = $adapter->authenticate( $credentials );
+
+		if ( ! $success ) {
+			return new WP_Error(
+				'authentication_failed',
+				__( 'Failed to connect to the source. Please check your credentials and try again.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'source'  => $this->serialize_adapter( $adapter ),
+			)
+		);
+	}
+
+	/**
+	 * Disconnect a source adapter.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function disconnect_source( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		$adapter->disconnect();
+
+		return rest_ensure_response(
+			array(
+				'success' => true,
+				'source'  => $this->serialize_adapter( $adapter ),
+			)
+		);
+	}
+
+	/**
+	 * Fetch the content manifest for a connected source.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_manifest( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		if ( ! $adapter->is_authenticated() ) {
+			return new WP_Error(
+				'not_authenticated',
+				__( 'This source is not connected. Please connect it first.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		try {
+			$manifest = $adapter->fetch_manifest();
+		} catch ( \RuntimeException $e ) {
+			return new WP_Error(
+				'manifest_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+
+		return rest_ensure_response( $manifest->to_array() );
+	}
+
+	/**
+	 * Get an adapter by ID, returning WP_Error if not found.
+	 *
+	 * @param string $adapter_id Adapter ID.
+	 * @return \AI_Importer\Adapters\AdapterInterface|WP_Error
+	 */
+	private function get_adapter( string $adapter_id ) {
+		$registry = AdapterRegistry::get_instance();
+		$adapter  = $registry->get( $adapter_id );
+
+		if ( ! $adapter ) {
+			return new WP_Error(
+				'source_not_found',
+				sprintf(
+					/* translators: %s: adapter ID */
+					__( 'Source adapter "%s" not found.', 'ai-importer' ),
+					$adapter_id
+				),
+				array( 'status' => 404 )
+			);
+		}
+
+		return $adapter;
+	}
+
+	/**
+	 * Serialize an adapter to an array for API responses.
+	 *
+	 * @param \AI_Importer\Adapters\AdapterInterface $adapter The adapter.
+	 * @return array<string, mixed>
+	 */
+	private function serialize_adapter( $adapter ): array {
+		return array(
+			'id'               => $adapter->get_id(),
+			'name'             => $adapter->get_name(),
+			'description'      => $adapter->get_description(),
+			'icon'             => $adapter->get_icon(),
+			'auth_type'        => $adapter->get_auth_type(),
+			'is_authenticated' => $adapter->is_authenticated(),
+			'content_types'    => $adapter->get_supported_content_types(),
+		);
+	}
+
+	/**
+	 * Handle a file upload and return the temporary file path.
+	 *
+	 * @param array<string, mixed> $file Upload file data from $_FILES.
+	 * @return string|WP_Error File path or error.
+	 */
+	private function handle_file_upload( array $file ): string|WP_Error {
+		if ( ! empty( $file['error'] ) ) {
+			return new WP_Error(
+				'upload_error',
+				__( 'File upload failed.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( empty( $file['tmp_name'] ) || ! is_uploaded_file( $file['tmp_name'] ) ) {
+			return new WP_Error(
+				'upload_error',
+				__( 'Invalid file upload.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		// Move to a persistent temp location so it survives the request.
+		$upload_dir = wp_upload_dir();
+		$dest_dir   = $upload_dir['basedir'] . '/ai-importer-tmp';
+
+		if ( ! file_exists( $dest_dir ) ) {
+			wp_mkdir_p( $dest_dir );
+		}
+
+		$filename = wp_unique_filename( $dest_dir, sanitize_file_name( $file['name'] ) );
+		$dest     = $dest_dir . '/' . $filename;
+
+		// phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- move_uploaded_file may warn on permission issues.
+		if ( ! @move_uploaded_file( $file['tmp_name'], $dest ) ) {
+			return new WP_Error(
+				'upload_error',
+				__( 'Failed to save uploaded file.', 'ai-importer' ),
+				array( 'status' => 500 )
+			);
+		}
+
+		return $dest;
+	}
+}

--- a/tests/Unit/REST/ImportsControllerTest.php
+++ b/tests/Unit/REST/ImportsControllerTest.php
@@ -1,0 +1,392 @@
+<?php
+/**
+ * ImportsController tests.
+ *
+ * @package AI_Importer\Tests\Unit\REST
+ */
+
+namespace AI_Importer\Tests\Unit\REST;
+
+use AI_Importer\Adapters\AdapterInterface;
+use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\REST\ImportsController;
+use AI_Importer\Schema\SettingsSchema;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_REST_Request;
+
+/**
+ * Tests for the ImportsController class.
+ */
+class ImportsControllerTest extends TestCase {
+
+	/**
+	 * Controller instance.
+	 *
+	 * @var ImportsController
+	 */
+	private ImportsController $controller;
+
+	/**
+	 * In-memory option store for testing.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $options;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		AdapterRegistry::get_instance()->reset();
+		$this->controller = new ImportsController();
+		$this->options    = array();
+
+		// Mock WordPress functions.
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'rest_ensure_response' )->alias(
+			function ( $data ) {
+				if ( $data instanceof \WP_REST_Response ) {
+					return $data;
+				}
+				return new \WP_REST_Response( $data );
+			}
+		);
+		Functions\when( 'wp_generate_uuid4' )->justReturn( 'test-uuid-1234' );
+
+		// Use in-memory option store.
+		$options = &$this->options;
+
+		Functions\when( 'get_option' )->alias(
+			function ( $key, $default = false ) use ( &$options ) {
+				return $options[ $key ] ?? $default;
+			}
+		);
+
+		Functions\when( 'update_option' )->alias(
+			function ( $key, $value ) use ( &$options ) {
+				$options[ $key ] = $value;
+				return true;
+			}
+		);
+	}
+
+	/**
+	 * Test create_item creates a batch.
+	 *
+	 * @return void
+	 */
+	public function test_create_item(): void {
+		$this->register_mock_adapter( 'twitter', true );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/imports' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'item_ids'       => array( 'tweet-1', 'tweet-2', 'tweet-3' ),
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+		$data = $result->get_data();
+
+		$this->assertSame( 'test-uuid-1234', $data['id'] );
+		$this->assertSame( 'twitter', $data['source_adapter'] );
+		$this->assertSame( 'processing', $data['state'] );
+		$this->assertSame( 3, $data['total'] );
+		$this->assertSame( 0, $data['processed'] );
+		$this->assertSame( 0, $data['percentage'] );
+	}
+
+	/**
+	 * Test create_item rejects unknown adapter.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_invalid_source(): void {
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/imports' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'nonexistent',
+				'item_ids'       => array( '1' ),
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test create_item rejects unauthenticated adapter.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_not_authenticated(): void {
+		$this->register_mock_adapter( 'twitter', false );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/imports' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'item_ids'       => array( '1' ),
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test create_item rejects empty item_ids.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_empty_items(): void {
+		$this->register_mock_adapter( 'twitter', true );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/imports' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'item_ids'       => array(),
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test get_item returns batch progress.
+	 *
+	 * @return void
+	 */
+	public function test_get_item(): void {
+		$this->create_test_batch();
+
+		$request             = new WP_REST_Request( 'GET', '/ai-importer/v1/imports/test-uuid-1234' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->get_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertSame( 'test-uuid-1234', $result['id'] );
+		$this->assertSame( 'processing', $result['state'] );
+		$this->assertArrayHasKey( 'percentage', $result );
+		$this->assertArrayHasKey( 'state_label', $result );
+	}
+
+	/**
+	 * Test get_item returns error for unknown batch.
+	 *
+	 * @return void
+	 */
+	public function test_get_item_not_found(): void {
+		$request             = new WP_REST_Request( 'GET', '/ai-importer/v1/imports/nonexistent' );
+		$request['batch_id'] = 'nonexistent';
+		$result              = $this->controller->get_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test get_items returns batches in reverse order.
+	 *
+	 * @return void
+	 */
+	public function test_get_items(): void {
+		$this->create_test_batch( 'batch-1' );
+		$this->create_test_batch( 'batch-2' );
+
+		$request = new WP_REST_Request( 'GET', '/ai-importer/v1/imports' );
+		$request->set_param( 'limit', 10 );
+		$response = $this->controller->get_items( $request );
+		$result   = $response->get_data();
+
+		$this->assertCount( 2, $result );
+		// Newest first.
+		$this->assertSame( 'batch-2', $result[0]['id'] );
+		$this->assertSame( 'batch-1', $result[1]['id'] );
+	}
+
+	/**
+	 * Test pause_item pauses a processing batch.
+	 *
+	 * @return void
+	 */
+	public function test_pause_item(): void {
+		$this->create_test_batch();
+
+		$request             = new WP_REST_Request( 'POST', '/ai-importer/v1/imports/test-uuid-1234/pause' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->pause_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertSame( 'paused', $result['state'] );
+	}
+
+	/**
+	 * Test pause_item rejects non-processing batch.
+	 *
+	 * @return void
+	 */
+	public function test_pause_item_invalid_state(): void {
+		$this->create_test_batch( 'test-uuid-1234', 'completed' );
+
+		$request             = new WP_REST_Request( 'POST', '/ai-importer/v1/imports/test-uuid-1234/pause' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$result              = $this->controller->pause_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test resume_item resumes a paused batch.
+	 *
+	 * @return void
+	 */
+	public function test_resume_item(): void {
+		$this->create_test_batch( 'test-uuid-1234', 'paused' );
+
+		$request             = new WP_REST_Request( 'POST', '/ai-importer/v1/imports/test-uuid-1234/resume' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->resume_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertSame( 'processing', $result['state'] );
+	}
+
+	/**
+	 * Test resume_item rejects non-paused batch.
+	 *
+	 * @return void
+	 */
+	public function test_resume_item_invalid_state(): void {
+		$this->create_test_batch();
+
+		$request             = new WP_REST_Request( 'POST', '/ai-importer/v1/imports/test-uuid-1234/resume' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$result              = $this->controller->resume_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test delete_item rolls back a batch.
+	 *
+	 * @return void
+	 */
+	public function test_delete_item(): void {
+		Functions\when( 'wp_delete_post' )->justReturn( true );
+
+		$this->create_test_batch( 'test-uuid-1234', 'completed', array( 10, 11, 12 ) );
+
+		$request             = new WP_REST_Request( 'DELETE', '/ai-importer/v1/imports/test-uuid-1234' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->delete_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertSame( 'rolled_back', $result['state'] );
+	}
+
+	/**
+	 * Test permissions check denies unauthorized users.
+	 *
+	 * @return void
+	 */
+	public function test_permissions_check_denies_unauthorized(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$request = new WP_REST_Request( 'GET', '/ai-importer/v1/imports' );
+		$result  = $this->controller->permissions_check( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test batch serialization includes percentage.
+	 *
+	 * @return void
+	 */
+	public function test_batch_percentage_calculation(): void {
+		$this->create_test_batch( 'test-uuid-1234', 'processing', array(), 10, 5 );
+
+		$request             = new WP_REST_Request( 'GET', '/ai-importer/v1/imports/test-uuid-1234' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->get_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertSame( 50, $result['percentage'] );
+		$this->assertSame( 5, $result['processed'] );
+		$this->assertSame( 10, $result['total'] );
+	}
+
+	/**
+	 * Register a mock adapter in the registry.
+	 *
+	 * @param string $id              Adapter ID.
+	 * @param bool   $is_authenticated Whether adapter is authenticated.
+	 * @return void
+	 */
+	private function register_mock_adapter( string $id, bool $is_authenticated = false ): void {
+		$adapter = Mockery::mock( AdapterInterface::class );
+		$adapter->shouldReceive( 'get_id' )->andReturn( $id );
+		$adapter->shouldReceive( 'get_name' )->andReturn( ucfirst( $id ) );
+		$adapter->shouldReceive( 'get_description' )->andReturn( "The {$id} adapter." );
+		$adapter->shouldReceive( 'get_icon' )->andReturn( "dashicons-{$id}" );
+		$adapter->shouldReceive( 'get_auth_type' )->andReturn( 'file_upload' );
+		$adapter->shouldReceive( 'is_authenticated' )->andReturn( $is_authenticated );
+		$adapter->shouldReceive( 'get_supported_content_types' )->andReturn( array( 'post' ) );
+
+		AdapterRegistry::get_instance()->register( $adapter );
+	}
+
+	/**
+	 * Create a test batch in the in-memory store.
+	 *
+	 * @param string       $id           Batch ID.
+	 * @param string       $state        Batch state.
+	 * @param array<int>   $imported_ids Imported post IDs.
+	 * @param int          $total        Total items.
+	 * @param int          $processed    Processed count.
+	 * @return void
+	 */
+	private function create_test_batch(
+		string $id = 'test-uuid-1234',
+		string $state = 'processing',
+		array $imported_ids = array(),
+		int $total = 3,
+		int $processed = 0
+	): void {
+		$batch = array(
+			'id'             => $id,
+			'source_adapter' => 'twitter',
+			'state'          => $state,
+			'item_ids'       => array( '1', '2', '3' ),
+			'total'          => $total,
+			'processed'      => $processed,
+			'failed'         => 0,
+			'errors'         => array(),
+			'created_at'     => '2024-01-15T10:00:00+00:00',
+			'started_at'     => '2024-01-15T10:00:01+00:00',
+			'completed_at'   => null,
+			'imported_ids'   => $imported_ids,
+		);
+
+		$this->options[ 'ai_importer_batch_' . $id ] = $batch;
+
+		// Update index.
+		$index   = $this->options['ai_importer_batch_index'] ?? array();
+		$index[] = $id;
+		$this->options['ai_importer_batch_index'] = $index;
+	}
+}

--- a/tests/Unit/REST/SourcesControllerTest.php
+++ b/tests/Unit/REST/SourcesControllerTest.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * SourcesController tests.
+ *
+ * @package AI_Importer\Tests\Unit\REST
+ */
+
+namespace AI_Importer\Tests\Unit\REST;
+
+use AI_Importer\Adapters\AdapterInterface;
+use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Adapters\Manifest\ContentManifest;
+use AI_Importer\Adapters\Manifest\ContentType;
+use AI_Importer\Adapters\Manifest\ManifestItem;
+use AI_Importer\REST\SourcesController;
+use AI_Importer\Schema\SettingsSchema;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use DateTimeImmutable;
+use Mockery;
+use WP_REST_Request;
+
+/**
+ * Tests for the SourcesController class.
+ */
+class SourcesControllerTest extends TestCase {
+
+	/**
+	 * Controller instance.
+	 *
+	 * @var SourcesController
+	 */
+	private SourcesController $controller;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		AdapterRegistry::get_instance()->reset();
+		$this->controller = new SourcesController();
+
+		// Mock WordPress functions used by the controller.
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'rest_ensure_response' )->alias(
+			function ( $data ) {
+				if ( $data instanceof \WP_REST_Response ) {
+					return $data;
+				}
+				return new \WP_REST_Response( $data );
+			}
+		);
+	}
+
+	/**
+	 * Test get_items returns all registered adapters.
+	 *
+	 * @return void
+	 */
+	public function test_get_items(): void {
+		$this->register_mock_adapter( 'twitter' );
+		$this->register_mock_adapter( 'medium' );
+
+		$request  = new WP_REST_Request( 'GET', '/ai-importer/v1/sources' );
+		$response = $this->controller->get_items( $request );
+		$result   = $response->get_data();
+
+		$this->assertCount( 2, $result );
+		$this->assertSame( 'twitter', $result[0]['id'] );
+		$this->assertSame( 'medium', $result[1]['id'] );
+	}
+
+	/**
+	 * Test get_item returns single adapter with schema.
+	 *
+	 * @return void
+	 */
+	public function test_get_item(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter' );
+		$request['id'] = 'twitter';
+		$response      = $this->controller->get_item( $request );
+		$result        = $response->get_data();
+
+		$this->assertSame( 'twitter', $result['id'] );
+		$this->assertArrayHasKey( 'settings_schema', $result );
+	}
+
+	/**
+	 * Test get_item returns error for unknown adapter.
+	 *
+	 * @return void
+	 */
+	public function test_get_item_not_found(): void {
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/unknown' );
+		$request['id'] = 'unknown';
+		$result        = $this->controller->get_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test disconnect_source disconnects and returns updated adapter.
+	 *
+	 * @return void
+	 */
+	public function test_disconnect_source(): void {
+		$adapter = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'disconnect' )->once();
+
+		$request       = new WP_REST_Request( 'POST', '/ai-importer/v1/sources/twitter/disconnect' );
+		$request['id'] = 'twitter';
+		$response      = $this->controller->disconnect_source( $request );
+		$result        = $response->get_data();
+
+		$this->assertTrue( $result['success'] );
+		$this->assertSame( 'twitter', $result['source']['id'] );
+	}
+
+	/**
+	 * Test get_manifest returns manifest data.
+	 *
+	 * @return void
+	 */
+	public function test_get_manifest(): void {
+		$manifest = new ContentManifest( 'twitter' );
+		$manifest->add_item(
+			new ManifestItem(
+				id: '1',
+				type: ContentType::POST,
+				title: 'Test tweet',
+				created_at: new DateTimeImmutable( '2024-01-15' ),
+			)
+		);
+
+		$adapter = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/manifest' );
+		$request['id'] = 'twitter';
+		$response      = $this->controller->get_manifest( $request );
+		$result        = $response->get_data();
+
+		$this->assertSame( 'twitter', $result['source_id'] );
+		$this->assertSame( 1, $result['stats']['total'] );
+		$this->assertCount( 1, $result['items'] );
+	}
+
+	/**
+	 * Test get_manifest returns error when not authenticated.
+	 *
+	 * @return void
+	 */
+	public function test_get_manifest_not_authenticated(): void {
+		$this->register_mock_adapter( 'twitter', false );
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/manifest' );
+		$request['id'] = 'twitter';
+		$result        = $this->controller->get_manifest( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test permissions check denies unauthorized users.
+	 *
+	 * @return void
+	 */
+	public function test_permissions_check_denies_unauthorized(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$request = new WP_REST_Request( 'GET', '/ai-importer/v1/sources' );
+		$result  = $this->controller->get_items_permissions_check( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Register a mock adapter in the registry.
+	 *
+	 * @param string $id              Adapter ID.
+	 * @param bool   $is_authenticated Whether authenticated.
+	 * @return \Mockery\MockInterface&AdapterInterface Mock adapter.
+	 */
+	private function register_mock_adapter( string $id, bool $is_authenticated = false ) {
+		$schema = new SettingsSchema();
+
+		$adapter = Mockery::mock( AdapterInterface::class );
+		$adapter->shouldReceive( 'get_id' )->andReturn( $id );
+		$adapter->shouldReceive( 'get_name' )->andReturn( ucfirst( $id ) );
+		$adapter->shouldReceive( 'get_description' )->andReturn( "The {$id} adapter." );
+		$adapter->shouldReceive( 'get_icon' )->andReturn( "dashicons-{$id}" );
+		$adapter->shouldReceive( 'get_auth_type' )->andReturn( 'file_upload' );
+		$adapter->shouldReceive( 'is_authenticated' )->andReturn( $is_authenticated );
+		$adapter->shouldReceive( 'get_supported_content_types' )->andReturn( array( 'post' ) );
+		$adapter->shouldReceive( 'get_settings_schema' )->andReturn( $schema );
+
+		AdapterRegistry::get_instance()->register( $adapter );
+
+		return $adapter;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,6 +14,11 @@ define( 'AI_IMPORTER_PLUGIN_FILE', dirname( __DIR__ ) . '/ai-importer.php' );
 define( 'AI_IMPORTER_PLUGIN_DIR', dirname( __DIR__ ) . '/' );
 define( 'AI_IMPORTER_PLUGIN_URL', 'https://example.com/wp-content/plugins/ai-importer/' );
 
+// Define WordPress constants used by the plugin.
+if ( ! defined( 'ABSPATH' ) ) {
+	define( 'ABSPATH', '/tmp/wordpress/' );
+}
+
 /**
  * Stub WP_Error class for testing.
  */
@@ -110,5 +115,127 @@ if ( ! class_exists( 'WP_Error' ) ) {
 			}
 			return $this->error_data[ $code ] ?? null;
 		}
+	}
+}
+
+/**
+ * Stub WP_REST_Server class for testing.
+ */
+if ( ! class_exists( 'WP_REST_Server' ) ) {
+	class WP_REST_Server {
+		const READABLE   = 'GET';
+		const CREATABLE  = 'POST';
+		const EDITABLE   = 'PUT, PATCH';
+		const DELETABLE  = 'DELETE';
+		const ALLMETHODS  = 'GET, POST, PUT, PATCH, DELETE';
+	}
+}
+
+/**
+ * Stub WP_REST_Request class for testing.
+ */
+if ( ! class_exists( 'WP_REST_Request' ) ) {
+	class WP_REST_Request implements \ArrayAccess {
+		private $method;
+		private $route;
+		private $params      = array();
+		private $body_params  = array();
+		private $json_params  = array();
+		private $file_params  = array();
+		private $query_params = array();
+
+		public function __construct( $method = 'GET', $route = '' ) {
+			$this->method = $method;
+			$this->route  = $route;
+		}
+
+		public function get_param( $key ) {
+			return $this->params[ $key ] ?? $this->body_params[ $key ] ?? $this->query_params[ $key ] ?? null;
+		}
+
+		public function set_param( $key, $value ) {
+			$this->params[ $key ] = $value;
+		}
+
+		public function get_body_params() {
+			return $this->body_params;
+		}
+
+		public function set_body_params( $params ) {
+			$this->body_params = $params;
+			// Also set as regular params for get_param access.
+			$this->params = array_merge( $this->params, $params );
+		}
+
+		public function get_json_params() {
+			return $this->json_params;
+		}
+
+		public function get_file_params() {
+			return $this->file_params;
+		}
+
+		public function set_file_params( $params ) {
+			$this->file_params = $params;
+		}
+
+		public function get_query_params() {
+			return $this->query_params;
+		}
+
+		public function set_query_params( $params ) {
+			$this->query_params = $params;
+		}
+
+		public function offsetExists( $offset ): bool {
+			return isset( $this->params[ $offset ] );
+		}
+
+		public function offsetGet( $offset ): mixed {
+			return $this->params[ $offset ] ?? null;
+		}
+
+		public function offsetSet( $offset, $value ): void {
+			$this->params[ $offset ] = $value;
+		}
+
+		public function offsetUnset( $offset ): void {
+			unset( $this->params[ $offset ] );
+		}
+	}
+}
+
+/**
+ * Stub WP_REST_Response class for testing.
+ */
+if ( ! class_exists( 'WP_REST_Response' ) ) {
+	class WP_REST_Response {
+		private $data;
+		private $status;
+		private $headers = array();
+
+		public function __construct( $data = null, $status = 200, $headers = array() ) {
+			$this->data    = $data;
+			$this->status  = $status;
+			$this->headers = $headers;
+		}
+
+		public function get_data() {
+			return $this->data;
+		}
+
+		public function get_status() {
+			return $this->status;
+		}
+	}
+}
+
+/**
+ * Stub WP_REST_Controller class for testing.
+ */
+if ( ! class_exists( 'WP_REST_Controller' ) ) {
+	abstract class WP_REST_Controller {
+		protected $namespace;
+		protected $rest_base;
 	}
 }


### PR DESCRIPTION
## Summary

- Implement `SourcesController` with 5 endpoints for managing source adapters (list, get, connect, disconnect, manifest)
- Implement `ImportsController` with 6 endpoints for managing import batches (create, list, get, pause, resume, rollback)
- Wire controllers into `Plugin::register_rest_routes()`
- Add WP REST class stubs to test bootstrap

This connects the React admin UI (`src/api.js`) to the backend adapter system. All 11 endpoints the frontend expects are now implemented.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/sources` | List all adapters |
| GET | `/sources/{id}` | Get adapter + settings schema |
| POST | `/sources/{id}/connect` | Authenticate (JSON or file upload) |
| POST | `/sources/{id}/disconnect` | Disconnect adapter |
| GET | `/sources/{id}/manifest` | Fetch content manifest |
| POST | `/imports` | Create import batch |
| GET | `/imports` | List batches (newest first) |
| GET | `/imports/{batch_id}` | Get batch progress |
| POST | `/imports/{batch_id}/pause` | Pause batch |
| POST | `/imports/{batch_id}/resume` | Resume batch |
| DELETE | `/imports/{batch_id}` | Rollback (delete imported posts) |

## Design decisions

- All endpoints require `manage_options` capability
- Batch state stored in `wp_options` (`ai_importer_batch_{uuid}`)
- File uploads saved to `wp-content/uploads/ai-importer-tmp/`
- Action hooks fired on batch state changes (`ai_importer_batch_created`, `_paused`, `_resumed`, `_rolled_back`) for the future import processor (#7) to hook into
- Rollback deletes all imported posts via `wp_delete_post()`

## Test plan

- [x] 19 new unit tests (7 sources + 12 imports)
- [x] All 212 tests pass
- [x] PHP lint clean
- [x] PHPStan clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Activated REST API endpoints to manage source adapters (list, inspect with settings, authenticate/connect, disconnect, fetch manifest).
  * Added REST API endpoints for import batch lifecycle: create, list, fetch, pause, resume, and rollback with progress reporting.

* **Tests**
  * Added comprehensive unit tests for REST endpoints, permissions, lifecycle flows, error cases, manifest handling, and test environment stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->