### PR TITLE
Add AIService wrapper for WordPress native AI client

### DIFF
--- a/includes/AI/AIService.php
+++ b/includes/AI/AIService.php
@@ -24,7 +24,9 @@ class AIService {
 	 * @return bool True if wp_get_ai_client() exists and returns a usable client.
 	 */
 	public function is_available(): bool {
-		return ! is_wp_error( $this->get_client() ) && null !== $this->get_client();
+		$client = $this->get_client();
+
+		return null !== $client && ! is_wp_error( $client );
 	}
 
 	/**

--- a/includes/AI/AIService.php
+++ b/includes/AI/AIService.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * AI service wrapper.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Wrapper around WordPress native AI client (wp_get_ai_client()).
+ *
+ * Provides migration-specific methods for structured output generation.
+ * Content analysis, mapping suggestions, and enhancement handlers build
+ * on top of the low-level generate_structured() primitive exposed here.
+ */
+class AIService {
+
+	/**
+	 * Check whether an AI client is available on this site.
+	 *
+	 * @return bool True if wp_get_ai_client() exists and returns a usable client.
+	 */
+	public function is_available(): bool {
+		return ! is_wp_error( $this->get_client() ) && null !== $this->get_client();
+	}
+
+	/**
+	 * Generate a structured (JSON) response that conforms to the given schema.
+	 *
+	 * @param string               $prompt  Prompt text to send to the model.
+	 * @param array<string, mixed> $schema  JSON schema describing the expected output.
+	 * @param array<string, mixed> $options Additional options forwarded to the client.
+	 * @return array<string, mixed>|WP_Error Decoded response or error.
+	 */
+	public function generate_structured( string $prompt, array $schema, array $options = array() ) {
+		$client = $this->get_client();
+
+		if ( null === $client || is_wp_error( $client ) ) {
+			return new WP_Error(
+				'ai_unavailable',
+				__( 'WordPress AI client is not available. Configure an AI provider in site settings.', 'ai-importer' )
+			);
+		}
+
+		$request_options = array_merge(
+			$options,
+			array(
+				'response_format' => array(
+					'type'   => 'json_schema',
+					'schema' => $schema,
+				),
+			)
+		);
+
+		$response = $client->generate_text( $prompt, $request_options );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$decoded = json_decode( (string) $response, true );
+
+		if ( ! is_array( $decoded ) ) {
+			return new WP_Error(
+				'ai_invalid_response',
+				__( 'AI provider returned a response that was not valid JSON.', 'ai-importer' ),
+				array( 'response' => $response )
+			);
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Retrieve the WordPress AI client, if available.
+	 *
+	 * @return object|WP_Error|null Client instance, WP_Error on provider failure, null when unavailable.
+	 */
+	private function get_client() {
+		if ( ! function_exists( 'wp_get_ai_client' ) ) {
+			return null;
+		}
+
+		return wp_get_ai_client();
+	}
+}

--- a/tests/Unit/AI/AIServiceTest.php
+++ b/tests/Unit/AI/AIServiceTest.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ * AIService class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\AIService;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use WP_Error;
+
+/**
+ * Tests for the AIService class.
+ */
+class AIServiceTest extends TestCase {
+
+	/**
+	 * Test is_available returns true when client can be retrieved.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_returns_true_when_client_retrievable(): void {
+		$client = $this->create_mock_client( array( 'foo' => 'bar' ) );
+		Functions\when( 'wp_get_ai_client' )->justReturn( $client );
+
+		$service = new AIService();
+
+		$this->assertTrue( $service->is_available() );
+	}
+
+	/**
+	 * Test is_available returns false when wp_get_ai_client returns WP_Error.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_returns_false_when_client_errors(): void {
+		Functions\when( 'wp_get_ai_client' )->justReturn(
+			new WP_Error( 'no_provider', 'No AI provider configured.' )
+		);
+
+		$service = new AIService();
+
+		$this->assertFalse( $service->is_available() );
+	}
+
+	/**
+	 * Test is_available returns false when wp_get_ai_client returns null.
+	 *
+	 * @return void
+	 */
+	public function test_is_available_returns_false_when_client_null(): void {
+		Functions\when( 'wp_get_ai_client' )->justReturn( null );
+
+		$service = new AIService();
+
+		$this->assertFalse( $service->is_available() );
+	}
+
+	/**
+	 * Test generate_structured returns WP_Error when service unavailable.
+	 *
+	 * @return void
+	 */
+	public function test_generate_structured_returns_error_when_unavailable(): void {
+		Functions\when( 'wp_get_ai_client' )->justReturn(
+			new WP_Error( 'no_provider', 'No AI provider configured.' )
+		);
+
+		$service = new AIService();
+
+		$result = $service->generate_structured(
+			'Summarize this post.',
+			array( 'type' => 'object' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate_structured returns decoded structured output on success.
+	 *
+	 * @return void
+	 */
+	public function test_generate_structured_returns_structured_data(): void {
+		$expected = array(
+			'topics'        => array( 'wordpress', 'javascript' ),
+			'writing_style' => 'technical',
+		);
+
+		$client = $this->create_mock_client( $expected );
+		Functions\when( 'wp_get_ai_client' )->justReturn( $client );
+
+		$service = new AIService();
+
+		$result = $service->generate_structured(
+			'Analyze the content.',
+			array( 'type' => 'object' )
+		);
+
+		$this->assertSame( $expected, $result );
+	}
+
+	/**
+	 * Test generate_structured propagates client errors.
+	 *
+	 * @return void
+	 */
+	public function test_generate_structured_propagates_client_errors(): void {
+		$client = new class() {
+			public function generate_text( $prompt, $options ) {
+				return new WP_Error( 'rate_limited', 'API rate limit hit.' );
+			}
+		};
+		Functions\when( 'wp_get_ai_client' )->justReturn( $client );
+
+		$service = new AIService();
+
+		$result = $service->generate_structured(
+			'Analyze.',
+			array( 'type' => 'object' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'rate_limited', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate_structured returns error when client returns non-JSON.
+	 *
+	 * @return void
+	 */
+	public function test_generate_structured_errors_on_invalid_json(): void {
+		$client = new class() {
+			public function generate_text( $prompt, $options ) {
+				return 'not valid json {{';
+			}
+		};
+		Functions\when( 'wp_get_ai_client' )->justReturn( $client );
+
+		$service = new AIService();
+
+		$result = $service->generate_structured(
+			'Analyze.',
+			array( 'type' => 'object' )
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_invalid_response', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate_structured passes prompt and schema to the client.
+	 *
+	 * @return void
+	 */
+	public function test_generate_structured_passes_prompt_and_schema(): void {
+		$received_prompt  = null;
+		$received_options = null;
+
+		$client = new class( $received_prompt, $received_options ) {
+			private $prompt_ref;
+			private $options_ref;
+
+			public function __construct( &$prompt_ref, &$options_ref ) {
+				$this->prompt_ref  = &$prompt_ref;
+				$this->options_ref = &$options_ref;
+			}
+
+			public function generate_text( $prompt, $options ) {
+				$this->prompt_ref  = $prompt;
+				$this->options_ref = $options;
+
+				return '{"ok":true}';
+			}
+		};
+		Functions\when( 'wp_get_ai_client' )->justReturn( $client );
+
+		$service = new AIService();
+
+		$schema = array(
+			'type'       => 'object',
+			'properties' => array( 'ok' => array( 'type' => 'boolean' ) ),
+		);
+
+		$service->generate_structured( 'Say ok.', $schema );
+
+		$this->assertSame( 'Say ok.', $received_prompt );
+		$this->assertArrayHasKey( 'response_format', $received_options );
+		$this->assertSame( 'json_schema', $received_options['response_format']['type'] );
+		$this->assertSame( $schema, $received_options['response_format']['schema'] );
+	}
+
+	/**
+	 * Create a mock AI client that returns the given data as a JSON string.
+	 *
+	 * @param array<string, mixed> $data Structured data to return as JSON.
+	 * @return object
+	 */
+	private function create_mock_client( array $data ): object {
+		$json = wp_json_encode_fallback( $data );
+
+		return new class( $json ) {
+			private string $json;
+
+			public function __construct( string $json ) {
+				$this->json = $json;
+			}
+
+			public function generate_text( $prompt, $options ) {
+				return $this->json;
+			}
+		};
+	}
+}
+
+/**
+ * Local fallback for wp_json_encode during tests.
+ *
+ * @param mixed $data Data to encode.
+ * @return string JSON string.
+ */
+function wp_json_encode_fallback( $data ): string {
+	return json_encode( $data ); // phpcs:ignore WordPress.WP.AlternativeFunctions.json_encode_json_encode
+}


### PR DESCRIPTION
## Summary

- Introduces `AIService` — a thin wrapper around `wp_get_ai_client()` that exposes two methods: `is_available()` and `generate_structured()`.
- Forms the foundation that content analysis, mapping suggestions, and enhancement handlers will build on (follow-up PRs for #8).
- 8 unit tests, all passing.

## Why this shape

- **`is_available()`** lets callers (UI, import processor) show the right fallback UI when no AI provider is configured, instead of crashing.
- **`generate_structured()`** takes a prompt + JSON schema and returns a decoded array. All WordPress-native AI tasks in this plugin produce structured output, so hiding the JSON parsing + validation here keeps callers clean.
- Errors are always `WP_Error` — client errors pass through; invalid JSON becomes `ai_invalid_response`; missing provider becomes `ai_unavailable`.

## Scope

This is the first of several PRs for #8. Follow-ups will add:
- Content analysis method (topics, writing style, content types)
- Mapping suggestion generator
- Enhancement handlers (alt text, thread stitching, titles, SEO meta)
- Cost estimation utility

Keeping them separate so each can be reviewed and merged independently.

## Test plan

- [x] 8 new `AIServiceTest` cases (available / unavailable / client errors / structured success / propagates errors / invalid JSON / prompt & schema passed through)
- [x] Full suite 274 tests pass
- [x] PHPCS clean
- [x] PHPStan clean

Closes part of #8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI-powered structured data generation with availability checks, clear error responses for unavailable or invalid AI client results, and automatic formatting of AI responses into structured JSON.

* **Tests**
  * Added unit tests covering availability, successful structured responses, error propagation, invalid-response handling, and verification that requests include the provided prompt and schema.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->