### PR TITLE
Add AltTextGenerator enhancement handler

### DIFF
--- a/includes/AI/AltTextGenerator.php
+++ b/includes/AI/AltTextGenerator.php
@@ -1,0 +1,136 @@
+<?php
+/**
+ * Alt text generator.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Generates accessibility alt text for an image via AIService.
+ *
+ * The AI is asked to produce a short, descriptive alt text for the image
+ * at the given URL. Optional context (e.g. the surrounding post text)
+ * improves relevance when the image alone is ambiguous.
+ */
+class AltTextGenerator {
+
+	/**
+	 * Maximum alt text length in characters.
+	 *
+	 * Screen readers start truncating around 125 characters; the prompt asks
+	 * the model to stay under this.
+	 */
+	private const MAX_LENGTH = 125;
+
+	/**
+	 * AI service.
+	 *
+	 * @var AIService
+	 */
+	private AIService $service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIService $service AI service wrapper.
+	 */
+	public function __construct( AIService $service ) {
+		$this->service = $service;
+	}
+
+	/**
+	 * Generate alt text for an image URL.
+	 *
+	 * @param string               $image_url HTTP(S) URL of the image.
+	 * @param array<string, mixed> $options   Options: 'context' (string) for surrounding text.
+	 * @return string|WP_Error Alt text or error.
+	 */
+	public function generate( string $image_url, array $options = array() ) {
+		if ( '' === trim( $image_url ) ) {
+			return new WP_Error(
+				'ai_alt_text_empty_url',
+				__( 'Image URL is required to generate alt text.', 'ai-importer' )
+			);
+		}
+
+		if ( false === filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+			return new WP_Error(
+				'ai_alt_text_invalid_url',
+				__( 'A valid http(s) URL is required to generate alt text.', 'ai-importer' )
+			);
+		}
+
+		$context = isset( $options['context'] ) ? (string) $options['context'] : '';
+		$prompt  = $this->build_prompt( $image_url, $context );
+		$schema  = $this->build_schema();
+
+		$response = $this->service->generate_structured( $prompt, $schema );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( ! array_key_exists( 'alt_text', $response ) || ! is_string( $response['alt_text'] ) ) {
+			return new WP_Error(
+				'ai_alt_text_malformed',
+				__( 'AI response did not include an alt_text string.', 'ai-importer' ),
+				array( 'response' => $response )
+			);
+		}
+
+		$alt = trim( $response['alt_text'] );
+		if ( '' === $alt ) {
+			return new WP_Error(
+				'ai_alt_text_empty',
+				__( 'AI returned an empty alt text.', 'ai-importer' )
+			);
+		}
+
+		return $alt;
+	}
+
+	/**
+	 * Build the alt-text prompt.
+	 *
+	 * @param string $image_url Image URL to describe.
+	 * @param string $context   Surrounding content, if any.
+	 * @return string Prompt.
+	 */
+	private function build_prompt( string $image_url, string $context ): string {
+		$prompt = sprintf(
+			'Generate concise accessibility alt text (under %d characters) for the image at %s. '
+			. 'Describe what a sighted viewer would see; do not start with "Image of" or "Picture of".',
+			self::MAX_LENGTH,
+			$image_url
+		);
+
+		if ( '' !== $context ) {
+			$prompt .= "\n\nSurrounding context (may help disambiguate, but describe the image, not the context):\n" . $context;
+		}
+
+		return $prompt;
+	}
+
+	/**
+	 * JSON schema for the alt text response.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function build_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'alt_text' => array(
+					'type'        => 'string',
+					'description' => 'Short, descriptive alt text for the image.',
+					'maxLength'   => self::MAX_LENGTH,
+				),
+			),
+			'required'   => array( 'alt_text' ),
+		);
+	}
+}

--- a/includes/AI/AltTextGenerator.php
+++ b/includes/AI/AltTextGenerator.php
@@ -57,7 +57,11 @@ class AltTextGenerator {
 			);
 		}
 
-		if ( false === filter_var( $image_url, FILTER_VALIDATE_URL ) ) {
+		$scheme = wp_parse_url( $image_url, PHP_URL_SCHEME );
+		if ( false === filter_var( $image_url, FILTER_VALIDATE_URL )
+			|| ! is_string( $scheme )
+			|| ! in_array( strtolower( $scheme ), array( 'http', 'https' ), true )
+		) {
 			return new WP_Error(
 				'ai_alt_text_invalid_url',
 				__( 'A valid http(s) URL is required to generate alt text.', 'ai-importer' )
@@ -87,6 +91,21 @@ class AltTextGenerator {
 			return new WP_Error(
 				'ai_alt_text_empty',
 				__( 'AI returned an empty alt text.', 'ai-importer' )
+			);
+		}
+
+		if ( mb_strlen( $alt ) > self::MAX_LENGTH ) {
+			return new WP_Error(
+				'ai_alt_text_too_long',
+				sprintf(
+					/* translators: %d: maximum alt text length. */
+					__( 'AI returned alt text longer than %d characters.', 'ai-importer' ),
+					self::MAX_LENGTH
+				),
+				array(
+					'max_length' => self::MAX_LENGTH,
+					'length'     => mb_strlen( $alt ),
+				)
 			);
 		}
 

--- a/tests/Unit/AI/AltTextGeneratorTest.php
+++ b/tests/Unit/AI/AltTextGeneratorTest.php
@@ -10,12 +10,23 @@ namespace AI_Importer\Tests\Unit\AI;
 use AI_Importer\AI\AIService;
 use AI_Importer\AI\AltTextGenerator;
 use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
 use WP_Error;
 
 /**
  * Tests for the AltTextGenerator class.
  */
 class AltTextGeneratorTest extends TestCase {
+
+	/**
+	 * Set up shared stubs.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+	}
 
 	/**
 	 * Test generate returns WP_Error when URL is empty.
@@ -169,5 +180,39 @@ class AltTextGeneratorTest extends TestCase {
 
 		$this->assertInstanceOf( WP_Error::class, $result );
 		$this->assertContains( 'ai_alt_text_empty', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects non-http(s) URL schemes.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_non_http_schemes(): void {
+		$service   = $this->createMock( AIService::class );
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'ftp://example.com/cat.jpg' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_alt_text_invalid_url', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects responses longer than the max length.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_overly_long_alt_text(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'alt_text' => str_repeat( 'a', 200 ) )
+		);
+
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'https://example.com/cat.jpg' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_alt_text_too_long', $result->get_error_codes() );
 	}
 }

--- a/tests/Unit/AI/AltTextGeneratorTest.php
+++ b/tests/Unit/AI/AltTextGeneratorTest.php
@@ -1,0 +1,173 @@
+<?php
+/**
+ * AltTextGenerator class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\AltTextGenerator;
+use AI_Importer\Tests\Unit\TestCase;
+use WP_Error;
+
+/**
+ * Tests for the AltTextGenerator class.
+ */
+class AltTextGeneratorTest extends TestCase {
+
+	/**
+	 * Test generate returns WP_Error when URL is empty.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_error_on_empty_url(): void {
+		$service   = $this->createMock( AIService::class );
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( '' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_alt_text_empty_url', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate returns WP_Error on clearly invalid URL.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_error_on_invalid_url(): void {
+		$service   = $this->createMock( AIService::class );
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'not-a-url' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_alt_text_invalid_url', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate propagates AIService errors.
+	 *
+	 * @return void
+	 */
+	public function test_generate_propagates_service_errors(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			new WP_Error( 'ai_unavailable', 'No provider configured.' )
+		);
+
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'https://example.com/cat.jpg' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate returns alt text on success.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_alt_text(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'alt_text' => 'A tabby cat sitting on a windowsill.' )
+		);
+
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'https://example.com/cat.jpg' );
+
+		$this->assertSame( 'A tabby cat sitting on a windowsill.', $result );
+	}
+
+	/**
+	 * Test generate includes image URL in prompt.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_url_in_prompt(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'alt_text' => 'description' );
+			}
+		);
+
+		$generator = new AltTextGenerator( $service );
+		$generator->generate( 'https://example.com/photo.png' );
+
+		$this->assertStringContainsString( 'https://example.com/photo.png', $captured_prompt );
+	}
+
+	/**
+	 * Test generate includes context option in the prompt when provided.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_context(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'alt_text' => 'description' );
+			}
+		);
+
+		$generator = new AltTextGenerator( $service );
+		$generator->generate(
+			'https://example.com/photo.png',
+			array( 'context' => 'Post about WordPress 7 launch.' )
+		);
+
+		$this->assertStringContainsString( 'WordPress 7 launch', $captured_prompt );
+	}
+
+	/**
+	 * Test generate rejects malformed responses missing the alt_text field.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_malformed_response(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'description' => 'A cat.' )
+		);
+
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'https://example.com/cat.jpg' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_alt_text_malformed', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate returns WP_Error when response alt_text is empty.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_empty_alt_text(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'alt_text' => '' )
+		);
+
+		$generator = new AltTextGenerator( $service );
+
+		$result = $generator->generate( 'https://example.com/cat.jpg' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_alt_text_empty', $result->get_error_codes() );
+	}
+}


### PR DESCRIPTION
## Summary

Fourth slice of #8. First **enhancement handler** on top of `AIService` — generates accessibility alt text for images.

## What it does

```php
$generator = new AltTextGenerator( $ai_service );
$alt = $generator->generate(
    'https://example.com/photo.png',
    array( 'context' => 'Post about WordPress 7 launch.' )
);
// => "Developer typing on a laptop with WordPress admin visible on screen."
```

- Validates URL (empty/malformed rejected early — no wasted AI call).
- Returns a plain string on success; `WP_Error` otherwise.
- Response validation catches malformed AI output (missing `alt_text` field, empty string).
- Caps output at 125 chars (screen-reader truncation threshold) via schema `maxLength` + explicit prompt instruction.
- Optional `context` option for surrounding post text — helps disambiguate when the image alone is unclear.

## Design choice

Each enhancement type gets its own class rather than a big switch in a single `Enhancer` — each has different inputs (URL vs body text vs thread of items), different schemas, and different validation. Alt text sets the pattern; title/excerpt/SEO-meta handlers will follow the same shape.

## Test plan

- [x] 8 unit tests (empty URL, invalid URL, service error, success, URL in prompt, context in prompt, malformed response, empty alt text)
- [x] Full suite 282 tests pass
- [x] PHPCS clean
- [x] PHPStan clean

Part of #8. Independent of #61 and #62 — merges in any order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * AI-powered image alt text generation with URL validation, optional context input, strict 125-character limit, and clear error responses for invalid or malformed results.

* **Tests**
  * Comprehensive unit tests covering input validation, non-HTTP schemes, propagation of service errors, malformed/empty/overlong AI responses, prompt construction, and successful alt-text generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->