### PR TITLE
Add CostEstimator for pre-import AI cost previews

### DIFF
--- a/includes/AI/CostEstimator.php
+++ b/includes/AI/CostEstimator.php
@@ -104,7 +104,14 @@ class CostEstimator {
 		$rates            = $this->get_rates();
 		$cost_by_provider = array();
 		foreach ( $rates as $provider => $rate_per_million ) {
-			$cost_by_provider[ $provider ] = round( ( $total_tokens / 1_000_000 ) * $rate_per_million, 2 );
+			if ( ! is_numeric( $rate_per_million ) ) {
+				continue;
+			}
+			$rate = (float) $rate_per_million;
+			if ( $rate < 0 ) {
+				continue;
+			}
+			$cost_by_provider[ $provider ] = round( ( $total_tokens / 1_000_000 ) * $rate, 2 );
 		}
 
 		return array(

--- a/includes/AI/CostEstimator.php
+++ b/includes/AI/CostEstimator.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Cost estimator for AI-powered enhancements.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Estimates token usage and USD cost for a planned batch of AI enhancements.
+ *
+ * No AI calls are made — this is pure math based on per-enhancement token
+ * estimates and per-provider pricing. Used by the import preview UI to show
+ * users what an enhancement selection will cost before they confirm.
+ */
+class CostEstimator {
+
+	/**
+	 * Average tokens consumed by each enhancement type (prompt + completion).
+	 *
+	 * These are coarse estimates drawn from the PRD. Real usage will vary by
+	 * content length; the purpose is to give users a realistic order of
+	 * magnitude before they commit to an import.
+	 *
+	 * @var array<string, int>
+	 */
+	private const TOKENS_PER_OPERATION = array(
+		'alt_text'          => 150,
+		'thread_stitching'  => 500,
+		'title_generation'  => 100,
+		'excerpt'           => 150,
+		'seo_meta'          => 100,
+		'content_expansion' => 400,
+		'hashtag_mapping'   => 50,
+		'content_analysis'  => 2000, // Single call with a sample of items.
+		'mapping_suggest'   => 1500, // Single call per import.
+	);
+
+	/**
+	 * Default per-million-token blended rates in USD.
+	 *
+	 * These are approximations that weight input and output tokens together.
+	 * Override via the 'ai_importer_cost_rates' filter for live pricing or
+	 * to add/remove providers.
+	 *
+	 * @var array<string, float>
+	 */
+	private const DEFAULT_RATES_PER_MILLION = array(
+		'claude_sonnet' => 5.0,
+		'claude_opus'   => 15.0,
+		'gpt_4o'        => 5.0,
+		'gpt_4_turbo'   => 10.0,
+		'gemini_pro'    => 1.5,
+	);
+
+	/**
+	 * Estimate cost for a plan of enhancements.
+	 *
+	 * @param array<string, int> $plan Map of enhancement name => count of items to process.
+	 * @return array<string, mixed>|WP_Error {
+	 *     operations: map of enhancement name => ['count' => int, 'tokens' => int],
+	 *     total_tokens: int,
+	 *     cost_by_provider: map of provider name => float USD
+	 * }
+	 */
+	public function estimate( array $plan ) {
+		$operations   = array();
+		$total_tokens = 0;
+
+		foreach ( $plan as $enhancement => $count ) {
+			if ( ! isset( self::TOKENS_PER_OPERATION[ $enhancement ] ) ) {
+				return new WP_Error(
+					'ai_cost_unknown_enhancement',
+					sprintf(
+						/* translators: %s: enhancement name */
+						__( 'Unknown enhancement type: %s.', 'ai-importer' ),
+						$enhancement
+					)
+				);
+			}
+
+			if ( ! is_int( $count ) || $count < 0 ) {
+				return new WP_Error(
+					'ai_cost_invalid_count',
+					sprintf(
+						/* translators: %s: enhancement name */
+						__( 'Enhancement count must be a non-negative integer: %s.', 'ai-importer' ),
+						$enhancement
+					)
+				);
+			}
+
+			$tokens                     = $count * self::TOKENS_PER_OPERATION[ $enhancement ];
+			$operations[ $enhancement ] = array(
+				'count'  => $count,
+				'tokens' => $tokens,
+			);
+			$total_tokens              += $tokens;
+		}
+
+		$rates            = $this->get_rates();
+		$cost_by_provider = array();
+		foreach ( $rates as $provider => $rate_per_million ) {
+			$cost_by_provider[ $provider ] = round( ( $total_tokens / 1_000_000 ) * $rate_per_million, 2 );
+		}
+
+		return array(
+			'operations'       => $operations,
+			'total_tokens'     => $total_tokens,
+			'cost_by_provider' => $cost_by_provider,
+		);
+	}
+
+	/**
+	 * Resolve the rates table, honoring the ai_importer_cost_rates filter.
+	 *
+	 * @return array<string, float>
+	 */
+	private function get_rates(): array {
+		/**
+		 * Filter the per-million-token blended USD rates used for cost estimation.
+		 *
+		 * Return an associative array of provider name => float dollars per million tokens.
+		 * Replaces defaults entirely, so include every provider you want displayed.
+		 *
+		 * @param array<string, float> $rates Default rate table.
+		 */
+		return (array) apply_filters( 'ai_importer_cost_rates', self::DEFAULT_RATES_PER_MILLION );
+	}
+}

--- a/tests/Unit/AI/CostEstimatorTest.php
+++ b/tests/Unit/AI/CostEstimatorTest.php
@@ -139,4 +139,28 @@ class CostEstimatorTest extends TestCase {
 		$this->assertArrayNotHasKey( 'claude_sonnet', $result['cost_by_provider'] );
 		$this->assertEqualsWithDelta( 2.0, $result['cost_by_provider']['custom_provider'], 0.001 );
 	}
+
+	/**
+	 * Test invalid rate values from the filter are skipped instead of crashing.
+	 *
+	 * @return void
+	 */
+	public function test_invalid_filter_rates_are_skipped(): void {
+		Filters\expectApplied( 'ai_importer_cost_rates' )
+			->once()
+			->andReturn(
+				array(
+					'good'     => 5.0,
+					'string'   => 'free', // Non-numeric — should be skipped, not crash.
+					'negative' => -1.0,   // Negative — should be skipped.
+				)
+			);
+
+		$estimator = new CostEstimator();
+		$result    = $estimator->estimate( array( 'title_generation' => 10000 ) );
+
+		$this->assertArrayHasKey( 'good', $result['cost_by_provider'] );
+		$this->assertArrayNotHasKey( 'string', $result['cost_by_provider'] );
+		$this->assertArrayNotHasKey( 'negative', $result['cost_by_provider'] );
+	}
 }

--- a/tests/Unit/AI/CostEstimatorTest.php
+++ b/tests/Unit/AI/CostEstimatorTest.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * CostEstimator class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\CostEstimator;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Filters;
+use WP_Error;
+
+/**
+ * Tests for the CostEstimator class.
+ */
+class CostEstimatorTest extends TestCase {
+
+	/**
+	 * Test empty plan returns zero everything.
+	 *
+	 * @return void
+	 */
+	public function test_empty_plan_returns_zero(): void {
+		$estimator = new CostEstimator();
+
+		$result = $estimator->estimate( array() );
+
+		$this->assertSame( 0, $result['total_tokens'] );
+		$this->assertSame( array(), $result['operations'] );
+		$this->assertArrayHasKey( 'cost_by_provider', $result );
+		foreach ( $result['cost_by_provider'] as $cost ) {
+			$this->assertSame( 0.0, $cost );
+		}
+	}
+
+	/**
+	 * Test single enhancement returns matching token and cost estimates.
+	 *
+	 * @return void
+	 */
+	public function test_single_enhancement_estimates(): void {
+		$estimator = new CostEstimator();
+
+		$result = $estimator->estimate( array( 'alt_text' => 100 ) );
+
+		$this->assertArrayHasKey( 'alt_text', $result['operations'] );
+		$this->assertSame( 100, $result['operations']['alt_text']['count'] );
+		$this->assertSame( 15000, $result['operations']['alt_text']['tokens'] ); // 100 * 150.
+		$this->assertSame( 15000, $result['total_tokens'] );
+		$this->assertGreaterThan( 0, $result['cost_by_provider']['claude_sonnet'] );
+	}
+
+	/**
+	 * Test multiple enhancements sum correctly.
+	 *
+	 * @return void
+	 */
+	public function test_multiple_enhancements_sum(): void {
+		$estimator = new CostEstimator();
+
+		$result = $estimator->estimate(
+			array(
+				'alt_text'         => 10,    // 10 * 150  = 1500.
+				'title_generation' => 20,    // 20 * 100  = 2000.
+				'seo_meta'         => 5,     // 5  * 100  = 500.
+			)
+		);
+
+		$this->assertSame( 4000, $result['total_tokens'] );
+		$this->assertCount( 3, $result['operations'] );
+	}
+
+	/**
+	 * Test unknown enhancement returns WP_Error.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_enhancement_returns_error(): void {
+		$estimator = new CostEstimator();
+
+		$result = $estimator->estimate( array( 'not_a_real_enhancement' => 5 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_cost_unknown_enhancement', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test negative count returns WP_Error.
+	 *
+	 * @return void
+	 */
+	public function test_negative_count_returns_error(): void {
+		$estimator = new CostEstimator();
+
+		$result = $estimator->estimate( array( 'alt_text' => -5 ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_cost_invalid_count', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test cost breakdown uses per-million-token rates.
+	 *
+	 * 1M tokens × $5/M for Claude Sonnet = $5.00.
+	 *
+	 * @return void
+	 */
+	public function test_cost_uses_per_million_rates(): void {
+		$estimator = new CostEstimator();
+
+		// 1,000,000 / 150 tokens-per-alt-text ≈ 6667 alt texts -> 1,000,050 tokens; close enough to test scale.
+		// Use title_generation @ 100 tokens each: 10000 * 100 = 1,000,000 tokens.
+		$result = $estimator->estimate( array( 'title_generation' => 10000 ) );
+
+		$this->assertSame( 1_000_000, $result['total_tokens'] );
+		$this->assertEqualsWithDelta( 5.0, $result['cost_by_provider']['claude_sonnet'], 0.001 );
+	}
+
+	/**
+	 * Test ai_importer_cost_rates filter can override provider rates.
+	 *
+	 * @return void
+	 */
+	public function test_rates_filter_overrides_defaults(): void {
+		Filters\expectApplied( 'ai_importer_cost_rates' )
+			->once()
+			->andReturn(
+				array(
+					'custom_provider' => 2.0,
+				)
+			);
+
+		$estimator = new CostEstimator();
+		$result    = $estimator->estimate( array( 'title_generation' => 10000 ) );
+
+		$this->assertArrayHasKey( 'custom_provider', $result['cost_by_provider'] );
+		$this->assertArrayNotHasKey( 'claude_sonnet', $result['cost_by_provider'] );
+		$this->assertEqualsWithDelta( 2.0, $result['cost_by_provider']['custom_provider'], 0.001 );
+	}
+}


### PR DESCRIPTION
## Summary

Fifth slice of #8. Adds `CostEstimator` — given an enhancement plan (map of enhancement name → item count), returns token estimates and USD cost breakdown across providers. **No AI calls made** — pure math, safe to run on every render of the import preview.

## Usage

```php
$estimator = new CostEstimator();
$estimate  = $estimator->estimate(
    array(
        'alt_text'         => 892,
        'thread_stitching' => 147,
        'seo_meta'         => 2104,
    )
);
// => [
//   'operations' => [
//     'alt_text'         => ['count' => 892,  'tokens' => 133800],
//     'thread_stitching' => ['count' => 147,  'tokens' => 73500],
//     'seo_meta'         => ['count' => 2104, 'tokens' => 210400],
//   ],
//   'total_tokens' => 417700,
//   'cost_by_provider' => [
//     'claude_sonnet' => 2.09,
//     'claude_opus'   => 6.27,
//     'gpt_4o'        => 2.09,
//     'gpt_4_turbo'   => 4.18,
//     'gemini_pro'    => 0.63,
//   ],
// ]
```

## Design

- **Token-per-operation estimates** come from the PRD's AI capabilities section (alt text ~150 tokens, thread stitching ~500, etc.).
- **Provider rates** are blended per-million-token USD figures, kept as a constant table.
- **`ai_importer_cost_rates` filter** — site owners or companion plugins can override the whole rate table for live pricing, new providers, or to remove defaults. Uses `(array)` cast so a filter misuse doesn't crash the estimator.
- **Input validation**: unknown enhancement types → `WP_Error`; negative counts → `WP_Error`. Catches bugs in calling code early.

## Test plan

- [x] 7 unit tests (empty plan, single enhancement, multiple enhancements, unknown type, negative count, per-million rate math, filter override)
- [x] Full suite 281 tests pass
- [x] PHPCS clean
- [x] PHPStan clean

Part of #8. Independent of #61, #62, #63 — merges in any order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added AI batch cost estimation that calculates token usage and per-provider costs; supports customizable provider rates via a filter.
  * Input validation with clear error responses for unknown enhancements or invalid counts.

* **Tests**
  * Added unit tests covering empty and multi-item plans, validation/error cases, rate override behavior, and skipping invalid provider rates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->