### PR TITLE
Add SiteSchemaAnalyzer to introspect destination WordPress structure

### DIFF
--- a/includes/Schema/SiteSchemaAnalyzer.php
+++ b/includes/Schema/SiteSchemaAnalyzer.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Site schema analyzer.
+ *
+ * @package AI_Importer\Schema
+ */
+
+namespace AI_Importer\Schema;
+
+/**
+ * Introspects the destination WordPress site's public structure.
+ *
+ * Produces a compact summary of post types and taxonomies in the exact
+ * shape that MappingSuggester consumes, so the AI has enough context to
+ * recommend how source content maps onto what actually exists on the site.
+ */
+class SiteSchemaAnalyzer {
+
+	/**
+	 * Build a summary of the site's public post types and taxonomies.
+	 *
+	 * @return array{post_types: array<int, array<string, mixed>>, taxonomies: array<int, array<string, mixed>>}
+	 */
+	public function get_schema(): array {
+		return array(
+			'post_types' => $this->collect_post_types(),
+			'taxonomies' => $this->collect_taxonomies(),
+		);
+	}
+
+	/**
+	 * Collect public post types into the expected output shape.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function collect_post_types(): array {
+		$post_types = get_post_types( array( 'public' => true ), 'objects' );
+
+		$result = array();
+		foreach ( $post_types as $post_type ) {
+			$result[] = array(
+				'slug'   => $post_type->name,
+				'name'   => $this->resolve_label( $post_type, $post_type->name ),
+				'public' => (bool) $post_type->public,
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Collect public taxonomies, recording which post types they apply to.
+	 *
+	 * @return array<int, array<string, mixed>>
+	 */
+	private function collect_taxonomies(): array {
+		$taxonomies = get_taxonomies( array( 'public' => true ), 'objects' );
+
+		$result = array();
+		foreach ( $taxonomies as $taxonomy ) {
+			$result[] = array(
+				'slug'       => $taxonomy->name,
+				'name'       => $this->resolve_label( $taxonomy, $taxonomy->name ),
+				'post_types' => array_values( $taxonomy->object_type ),
+			);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Resolve a human-readable label for a post type or taxonomy object.
+	 *
+	 * @param object $entity   Post type or taxonomy object.
+	 * @param string $fallback Fallback slug.
+	 * @return string
+	 */
+	private function resolve_label( object $entity, string $fallback ): string {
+		if ( isset( $entity->label ) && is_string( $entity->label ) && '' !== $entity->label ) {
+			return $entity->label;
+		}
+
+		if ( isset( $entity->labels->name ) && is_string( $entity->labels->name ) ) {
+			return $entity->labels->name;
+		}
+
+		return $fallback;
+	}
+}

--- a/tests/Unit/Schema/SiteSchemaAnalyzerTest.php
+++ b/tests/Unit/Schema/SiteSchemaAnalyzerTest.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * SiteSchemaAnalyzer class tests.
+ *
+ * @package AI_Importer\Tests\Unit\Schema
+ */
+
+namespace AI_Importer\Tests\Unit\Schema;
+
+use AI_Importer\Schema\SiteSchemaAnalyzer;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests for the SiteSchemaAnalyzer class.
+ */
+class SiteSchemaAnalyzerTest extends TestCase {
+
+	/**
+	 * Build a minimal WP_Post_Type-like stub.
+	 *
+	 * @param string $name   Slug.
+	 * @param string $label  Display label.
+	 * @param bool   $public Public flag.
+	 * @return object
+	 */
+	private function make_post_type( string $name, string $label, bool $public = true ): object {
+		$type = new \stdClass();
+		$type->name   = $name;
+		$type->label  = $label;
+		$type->public = $public;
+		$type->labels = (object) array( 'singular_name' => $label );
+
+		return $type;
+	}
+
+	/**
+	 * Build a minimal WP_Taxonomy-like stub.
+	 *
+	 * @param string        $name       Slug.
+	 * @param string        $label      Label.
+	 * @param array<string> $post_types Associated post type slugs.
+	 * @return object
+	 */
+	private function make_taxonomy( string $name, string $label, array $post_types ): object {
+		$tax = new \stdClass();
+		$tax->name       = $name;
+		$tax->label      = $label;
+		$tax->public     = true;
+		$tax->object_type = $post_types;
+
+		return $tax;
+	}
+
+	/**
+	 * Test empty site returns empty structure.
+	 *
+	 * @return void
+	 */
+	public function test_empty_site_returns_empty_structure(): void {
+		Functions\when( 'get_post_types' )->justReturn( array() );
+		Functions\when( 'get_taxonomies' )->justReturn( array() );
+
+		$analyzer = new SiteSchemaAnalyzer();
+		$schema   = $analyzer->get_schema();
+
+		$this->assertSame( array(), $schema['post_types'] );
+		$this->assertSame( array(), $schema['taxonomies'] );
+	}
+
+	/**
+	 * Test post types are returned in the expected shape.
+	 *
+	 * @return void
+	 */
+	public function test_returns_public_post_types(): void {
+		Functions\when( 'get_post_types' )->justReturn(
+			array(
+				'post'     => $this->make_post_type( 'post', 'Posts' ),
+				'tutorial' => $this->make_post_type( 'tutorial', 'Tutorials' ),
+			)
+		);
+		Functions\when( 'get_taxonomies' )->justReturn( array() );
+
+		$analyzer = new SiteSchemaAnalyzer();
+		$schema   = $analyzer->get_schema();
+
+		$this->assertCount( 2, $schema['post_types'] );
+		$this->assertSame(
+			array(
+				'slug'   => 'post',
+				'name'   => 'Posts',
+				'public' => true,
+			),
+			$schema['post_types'][0]
+		);
+		$this->assertSame( 'tutorial', $schema['post_types'][1]['slug'] );
+	}
+
+	/**
+	 * Test taxonomies include their associated post types.
+	 *
+	 * @return void
+	 */
+	public function test_returns_taxonomies_with_post_types(): void {
+		Functions\when( 'get_post_types' )->justReturn( array() );
+		Functions\when( 'get_taxonomies' )->justReturn(
+			array(
+				'category' => $this->make_taxonomy( 'category', 'Categories', array( 'post', 'tutorial' ) ),
+				'post_tag' => $this->make_taxonomy( 'post_tag', 'Tags', array( 'post' ) ),
+			)
+		);
+
+		$analyzer = new SiteSchemaAnalyzer();
+		$schema   = $analyzer->get_schema();
+
+		$this->assertCount( 2, $schema['taxonomies'] );
+		$this->assertSame(
+			array(
+				'slug'       => 'category',
+				'name'       => 'Categories',
+				'post_types' => array( 'post', 'tutorial' ),
+			),
+			$schema['taxonomies'][0]
+		);
+	}
+
+	/**
+	 * Test built-in WordPress internals are excluded by default.
+	 *
+	 * @return void
+	 */
+	public function test_excludes_wordpress_internals(): void {
+		// WordPress get_post_types filters by args passed in; the analyzer passes
+		// public => true, so internals like attachment aren't returned. We verify
+		// the args by capturing what the analyzer calls get_post_types with.
+		$captured_args = null;
+		Functions\expect( 'get_post_types' )
+			->once()
+			->with(
+				\Mockery::on(
+					function ( $args ) use ( &$captured_args ) {
+						$captured_args = $args;
+						return true;
+					}
+				),
+				'objects'
+			)
+			->andReturn( array() );
+		Functions\when( 'get_taxonomies' )->justReturn( array() );
+
+		$analyzer = new SiteSchemaAnalyzer();
+		$analyzer->get_schema();
+
+		$this->assertIsArray( $captured_args );
+		$this->assertArrayHasKey( 'public', $captured_args );
+		$this->assertTrue( $captured_args['public'] );
+	}
+
+	/**
+	 * Test produces output compatible with MappingSuggester consumer.
+	 *
+	 * @return void
+	 */
+	public function test_output_shape_matches_mapping_suggester_contract(): void {
+		Functions\when( 'get_post_types' )->justReturn(
+			array( 'post' => $this->make_post_type( 'post', 'Posts' ) )
+		);
+		Functions\when( 'get_taxonomies' )->justReturn(
+			array( 'category' => $this->make_taxonomy( 'category', 'Categories', array( 'post' ) ) )
+		);
+
+		$analyzer = new SiteSchemaAnalyzer();
+		$schema   = $analyzer->get_schema();
+
+		// Top-level keys MappingSuggester expects.
+		$this->assertArrayHasKey( 'post_types', $schema );
+		$this->assertArrayHasKey( 'taxonomies', $schema );
+
+		// Per-entry keys MappingSuggester reads.
+		$this->assertArrayHasKey( 'slug', $schema['post_types'][0] );
+		$this->assertArrayHasKey( 'name', $schema['post_types'][0] );
+		$this->assertArrayHasKey( 'slug', $schema['taxonomies'][0] );
+		$this->assertArrayHasKey( 'name', $schema['taxonomies'][0] );
+		$this->assertArrayHasKey( 'post_types', $schema['taxonomies'][0] );
+	}
+}


### PR DESCRIPTION
## Summary

Completes the producer half of the AI mapping loop. `SiteSchemaAnalyzer` introspects the live WordPress site and returns a compact summary of public post types and taxonomies in the exact shape that `MappingSuggester` (#62) consumes.

## Usage

```php
\$analyzer = new SiteSchemaAnalyzer();
\$schema   = \$analyzer->get_schema();
// => [
//   'post_types' => [
//     ['slug' => 'post',     'name' => 'Posts',     'public' => true],
//     ['slug' => 'tutorial', 'name' => 'Tutorials', 'public' => true],
//   ],
//   'taxonomies' => [
//     ['slug' => 'category', 'name' => 'Categories', 'post_types' => ['post', 'tutorial']],
//     ['slug' => 'post_tag', 'name' => 'Tags',       'post_types' => ['post']],
//   ],
// ]

// Now ready to feed MappingSuggester:
\$suggester = new MappingSuggester( \$ai_service );
\$suggestions = \$suggester->suggest( \$content_analysis, \$schema );
```

## Scope

- **Public post types and taxonomies only.** Internal types (attachment, nav_menu_item, revision) are excluded automatically by passing `public => true` to `get_post_types()` / `get_taxonomies()`.
- **Custom fields deliberately excluded.** ACF / Meta Box / CMB2 integration can be layered in once the basic flow is proven. Adding them here would couple this class to specific plugins.
- **Human-readable labels** — uses `\$entity->label`, falls back to `labels->name`, then the slug.

## Test plan

- [x] 5 unit tests (empty site, post types shape, taxonomies with post types, public-only args passed through, shape matches MappingSuggester contract)
- [x] Full suite 279 tests pass
- [x] PHPCS clean
- [x] PHPStan clean

Unblocks end-to-end use of #62 MappingSuggester against a real site. Independent of #61/#62/#63/#64 — merges in any order.

Part of #11 (AI Analysis & Mapping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated site schema analysis to detect and catalog public content types and taxonomies.

* **Tests**
  * Added comprehensive test coverage for schema detection and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->