### PR TITLE
Add TitleGenerator enhancement handler

### DIFF
--- a/includes/AI/TitleGenerator.php
+++ b/includes/AI/TitleGenerator.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Post title generator.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Proposes a concise post title for imported content via AIService.
+ *
+ * Useful when the source item has no native title (e.g. a tweet or a short
+ * status update) or when the source title is unsuitable for a long-form post.
+ */
+class TitleGenerator {
+
+	/**
+	 * Maximum title length in characters.
+	 *
+	 * Roughly the upper bound for SERP title display before truncation; the
+	 * prompt asks the model to stay under this.
+	 */
+	private const MAX_LENGTH = 70;
+
+	/**
+	 * AI service.
+	 *
+	 * @var AIService
+	 */
+	private AIService $service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIService $service AI service wrapper.
+	 */
+	public function __construct( AIService $service ) {
+		$this->service = $service;
+	}
+
+	/**
+	 * Generate a title for the given content.
+	 *
+	 * @param string               $content Post body (HTML or plain text).
+	 * @param array<string, mixed> $options Options: 'style' (string) e.g. "news", "casual".
+	 * @return string|WP_Error Title or error.
+	 */
+	public function generate( string $content, array $options = array() ) {
+		if ( '' === trim( $content ) ) {
+			return new WP_Error(
+				'ai_title_empty_content',
+				__( 'Content is required to generate a title.', 'ai-importer' )
+			);
+		}
+
+		$style  = isset( $options['style'] ) ? (string) $options['style'] : '';
+		$prompt = $this->build_prompt( $content, $style );
+		$schema = $this->build_schema();
+
+		$response = $this->service->generate_structured( $prompt, $schema );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( ! array_key_exists( 'title', $response ) || ! is_string( $response['title'] ) ) {
+			return new WP_Error(
+				'ai_title_malformed',
+				__( 'AI response did not include a title string.', 'ai-importer' ),
+				array( 'response' => $response )
+			);
+		}
+
+		$title = trim( $response['title'] );
+		if ( '' === $title ) {
+			return new WP_Error(
+				'ai_title_empty',
+				__( 'AI returned an empty title.', 'ai-importer' )
+			);
+		}
+
+		if ( mb_strlen( $title ) > self::MAX_LENGTH ) {
+			return new WP_Error(
+				'ai_title_too_long',
+				sprintf(
+					/* translators: %d: maximum title length. */
+					__( 'AI returned a title longer than %d characters.', 'ai-importer' ),
+					self::MAX_LENGTH
+				),
+				array(
+					'max_length' => self::MAX_LENGTH,
+					'length'     => mb_strlen( $title ),
+				)
+			);
+		}
+
+		return $title;
+	}
+
+	/**
+	 * Build the prompt for title generation.
+	 *
+	 * @param string $content Post content.
+	 * @param string $style   Optional style hint.
+	 * @return string Prompt.
+	 */
+	private function build_prompt( string $content, string $style ): string {
+		$prompt = sprintf(
+			'Propose a concise, compelling post title (under %d characters) for the content below. '
+			. 'Do not wrap the title in quotes. Do not include a trailing period.',
+			self::MAX_LENGTH
+		);
+
+		if ( '' !== $style ) {
+			$prompt .= sprintf( ' Match this style: %s.', $style );
+		}
+
+		$prompt .= "\n\nContent:\n" . $content;
+
+		return $prompt;
+	}
+
+	/**
+	 * JSON schema for the title response.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function build_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'title' => array(
+					'type'        => 'string',
+					'description' => 'A concise post title.',
+					'maxLength'   => self::MAX_LENGTH,
+				),
+			),
+			'required'   => array( 'title' ),
+		);
+	}
+}

--- a/tests/Unit/AI/TitleGeneratorTest.php
+++ b/tests/Unit/AI/TitleGeneratorTest.php
@@ -1,0 +1,174 @@
+<?php
+/**
+ * TitleGenerator class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\TitleGenerator;
+use AI_Importer\Tests\Unit\TestCase;
+use WP_Error;
+
+/**
+ * Tests for the TitleGenerator class.
+ */
+class TitleGeneratorTest extends TestCase {
+
+	/**
+	 * Test generate returns WP_Error on empty content.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_error_on_empty_content(): void {
+		$service   = $this->createMock( AIService::class );
+		$generator = new TitleGenerator( $service );
+
+		$result = $generator->generate( '   ' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_title_empty_content', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate propagates AIService errors.
+	 *
+	 * @return void
+	 */
+	public function test_generate_propagates_service_errors(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			new WP_Error( 'ai_unavailable', 'No provider configured.' )
+		);
+
+		$generator = new TitleGenerator( $service );
+
+		$result = $generator->generate( 'Some post content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate returns the title on success.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_title(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'title' => 'WordPress 7 launches native AI capabilities' )
+		);
+
+		$generator = new TitleGenerator( $service );
+
+		$result = $generator->generate( 'WordPress 7 has shipped with wp_get_ai_client...' );
+
+		$this->assertSame( 'WordPress 7 launches native AI capabilities', $result );
+	}
+
+	/**
+	 * Test generate forwards content into the prompt.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_content_in_prompt(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'title' => 'Some title' );
+			}
+		);
+
+		$generator = new TitleGenerator( $service );
+		$generator->generate( 'UNIQUE_MARKER_STRING_xyz content here.' );
+
+		$this->assertStringContainsString( 'UNIQUE_MARKER_STRING_xyz', $captured_prompt );
+	}
+
+	/**
+	 * Test generate includes a style hint when provided.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_style_option(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'title' => 'Headline-style title' );
+			}
+		);
+
+		$generator = new TitleGenerator( $service );
+		$generator->generate( 'Body content.', array( 'style' => 'news' ) );
+
+		$this->assertStringContainsString( 'news', $captured_prompt );
+	}
+
+	/**
+	 * Test generate rejects responses missing title field.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_malformed_response(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'headline' => 'Hello' )
+		);
+
+		$generator = new TitleGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_title_malformed', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects empty title.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_empty_title(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'title' => '   ' )
+		);
+
+		$generator = new TitleGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_title_empty', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects overly long titles.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_overly_long_title(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'title' => str_repeat( 'a', 100 ) )
+		);
+
+		$generator = new TitleGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_title_too_long', $result->get_error_codes() );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`TitleGenerator\` enhancement handler that proposes a concise post title for imported content via \`AIService\`
- Useful when the source item has no native title (e.g. a tweet) or when the source title is unsuitable for a long-form post
- 8 PHPUnit tests cover empty content, service errors, malformed/empty/too-long responses, and prompt content forwarding including an optional \`style\` hint

Part of epic #8 — one of the remaining enhancement task handlers called out in the technical notes.

## Test plan
- [x] \`./vendor/bin/phpunit --filter TitleGeneratorTest\` — 8 tests / 13 assertions
- [x] \`composer run lint\` — PHPCS clean
- [x] \`composer run phpstan\` — no errors
- [x] Full suite still green locally (pre-existing 311 tests + these 8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI-powered title generation with customizable style options. Automatically validates input content, enforces a maximum title length of 70 characters, and provides comprehensive error handling for various failure scenarios including empty content, unavailable AI services, invalid response formats, and titles that are empty or exceed the length limit.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->