### PR TITLE
Add MetaDescriptionGenerator enhancement handler

### DIFF
--- a/includes/AI/MetaDescriptionGenerator.php
+++ b/includes/AI/MetaDescriptionGenerator.php
@@ -1,0 +1,199 @@
+<?php
+/**
+ * SEO meta description generator.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Generates an SEO meta description for imported content via AIService.
+ *
+ * Targets the 150-160 character SERP snippet window. The output is
+ * intended to be saved to a meta-description field (e.g. Yoast, Rank
+ * Math, or a custom post meta key) by the caller.
+ */
+class MetaDescriptionGenerator {
+
+	/**
+	 * Maximum description length in characters.
+	 *
+	 * Chosen to stay within the typical SERP snippet truncation window;
+	 * the prompt and JSON schema both enforce this upper bound.
+	 */
+	private const MAX_LENGTH = 160;
+
+	/**
+	 * Minimum description length in characters.
+	 *
+	 * Extremely short descriptions tend to underperform in SERPs and are
+	 * rarely what the user wants; reject them explicitly.
+	 */
+	private const MIN_LENGTH = 50;
+
+	/**
+	 * AI service.
+	 *
+	 * @var AIService
+	 */
+	private AIService $service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIService $service AI service wrapper.
+	 */
+	public function __construct( AIService $service ) {
+		$this->service = $service;
+	}
+
+	/**
+	 * Generate an SEO meta description for the given content.
+	 *
+	 * @param string               $content Post body (HTML or plain text).
+	 * @param array<string, mixed> $options Options: 'title' (string), 'keywords' (string|string[]).
+	 * @return string|WP_Error Description or error.
+	 */
+	public function generate( string $content, array $options = array() ) {
+		if ( '' === trim( $content ) ) {
+			return new WP_Error(
+				'ai_meta_empty_content',
+				__( 'Content is required to generate a meta description.', 'ai-importer' )
+			);
+		}
+
+		$title    = isset( $options['title'] ) ? (string) $options['title'] : '';
+		$keywords = $this->normalize_keywords( $options['keywords'] ?? null );
+		$prompt   = $this->build_prompt( $content, $title, $keywords );
+		$schema   = $this->build_schema();
+
+		$response = $this->service->generate_structured( $prompt, $schema );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( ! array_key_exists( 'description', $response ) || ! is_string( $response['description'] ) ) {
+			return new WP_Error(
+				'ai_meta_malformed',
+				__( 'AI response did not include a description string.', 'ai-importer' ),
+				array( 'response' => $response )
+			);
+		}
+
+		$description = trim( $response['description'] );
+		$length      = mb_strlen( $description );
+
+		if ( '' === $description ) {
+			return new WP_Error(
+				'ai_meta_empty',
+				__( 'AI returned an empty meta description.', 'ai-importer' )
+			);
+		}
+
+		if ( $length < self::MIN_LENGTH ) {
+			return new WP_Error(
+				'ai_meta_too_short',
+				sprintf(
+					/* translators: %d: minimum description length. */
+					__( 'AI returned a meta description shorter than %d characters.', 'ai-importer' ),
+					self::MIN_LENGTH
+				),
+				array(
+					'min_length' => self::MIN_LENGTH,
+					'length'     => $length,
+				)
+			);
+		}
+
+		if ( $length > self::MAX_LENGTH ) {
+			return new WP_Error(
+				'ai_meta_too_long',
+				sprintf(
+					/* translators: %d: maximum description length. */
+					__( 'AI returned a meta description longer than %d characters.', 'ai-importer' ),
+					self::MAX_LENGTH
+				),
+				array(
+					'max_length' => self::MAX_LENGTH,
+					'length'     => $length,
+				)
+			);
+		}
+
+		return $description;
+	}
+
+	/**
+	 * Coerce a keywords option into a clean list of strings.
+	 *
+	 * @param mixed $keywords Raw input: string, array, or null.
+	 * @return array<int, string> Non-empty list of keyword strings.
+	 */
+	private function normalize_keywords( $keywords ): array {
+		if ( is_string( $keywords ) ) {
+			$keywords = array_map( 'trim', explode( ',', $keywords ) );
+		} elseif ( is_array( $keywords ) ) {
+			$keywords = array_map(
+				static fn( $k ) => is_string( $k ) ? trim( $k ) : '',
+				$keywords
+			);
+		} else {
+			return array();
+		}
+
+		return array_values( array_filter( $keywords, static fn( $k ) => '' !== $k ) );
+	}
+
+	/**
+	 * Build the prompt.
+	 *
+	 * @param string             $content  Post content.
+	 * @param string             $title    Optional title hint.
+	 * @param array<int, string> $keywords Optional keyword list.
+	 * @return string Prompt.
+	 */
+	private function build_prompt( string $content, string $title, array $keywords ): string {
+		$prompt = sprintf(
+			'Write an SEO meta description between %d and %d characters for the content below. '
+			. 'Summarize the main value proposition; do not wrap in quotes; do not exceed one or two sentences.',
+			self::MIN_LENGTH,
+			self::MAX_LENGTH
+		);
+
+		if ( '' !== $title ) {
+			$prompt .= "\n\nPost title: " . $title;
+		}
+
+		if ( ! empty( $keywords ) ) {
+			$prompt .= "\n\nTry to include these keywords naturally where they fit: " . implode( ', ', $keywords );
+		}
+
+		$prompt .= "\n\nContent:\n" . $content;
+
+		return $prompt;
+	}
+
+	/**
+	 * JSON schema for the meta description response.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function build_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'description' => array(
+					'type'        => 'string',
+					'description' => 'SEO meta description for the post.',
+					'minLength'   => self::MIN_LENGTH,
+					'maxLength'   => self::MAX_LENGTH,
+				),
+			),
+			'required'   => array( 'description' ),
+		);
+	}
+}

--- a/tests/Unit/AI/MetaDescriptionGeneratorTest.php
+++ b/tests/Unit/AI/MetaDescriptionGeneratorTest.php
@@ -1,0 +1,256 @@
+<?php
+/**
+ * MetaDescriptionGenerator class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\MetaDescriptionGenerator;
+use AI_Importer\Tests\Unit\TestCase;
+use WP_Error;
+
+/**
+ * Tests for the MetaDescriptionGenerator class.
+ */
+class MetaDescriptionGeneratorTest extends TestCase {
+
+	/**
+	 * A valid-length description for reuse across tests (exactly 100 chars).
+	 *
+	 * @var string
+	 */
+	private string $valid_description = 'A compelling, SEO-friendly summary of the post content that sits safely within the SERP snippet.';
+
+	/**
+	 * Test generate returns WP_Error on empty content.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_error_on_empty_content(): void {
+		$service   = $this->createMock( AIService::class );
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( '   ' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_meta_empty_content', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate propagates AIService errors.
+	 *
+	 * @return void
+	 */
+	public function test_generate_propagates_service_errors(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			new WP_Error( 'ai_unavailable', 'No provider configured.' )
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( 'Some post content long enough.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate returns the description on success.
+	 *
+	 * @return void
+	 */
+	public function test_generate_returns_description(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'description' => $this->valid_description )
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( 'Body content for the post.' );
+
+		$this->assertSame( $this->valid_description, $result );
+	}
+
+	/**
+	 * Test generate forwards content into the prompt.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_content_in_prompt(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'description' => $this->valid_description );
+			}
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+		$generator->generate( 'UNIQUE_MARKER_abc content about the launch.' );
+
+		$this->assertStringContainsString( 'UNIQUE_MARKER_abc', $captured_prompt );
+	}
+
+	/**
+	 * Test generate includes title when provided.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_title(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'description' => $this->valid_description );
+			}
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+		$generator->generate( 'Body.', array( 'title' => 'My Awesome Headline' ) );
+
+		$this->assertStringContainsString( 'My Awesome Headline', $captured_prompt );
+	}
+
+	/**
+	 * Test generate includes keywords when provided as array.
+	 *
+	 * @return void
+	 */
+	public function test_generate_includes_keywords_array(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'description' => $this->valid_description );
+			}
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+		$generator->generate(
+			'Body.',
+			array( 'keywords' => array( 'wordpress', 'ai', 'import' ) )
+		);
+
+		$this->assertStringContainsString( 'wordpress', $captured_prompt );
+		$this->assertStringContainsString( 'ai', $captured_prompt );
+		$this->assertStringContainsString( 'import', $captured_prompt );
+	}
+
+	/**
+	 * Test generate accepts a comma-delimited keywords string.
+	 *
+	 * @return void
+	 */
+	public function test_generate_accepts_keywords_string(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'description' => $this->valid_description );
+			}
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+		$generator->generate(
+			'Body.',
+			array( 'keywords' => ' gutenberg, blocks ,rest ' )
+		);
+
+		$this->assertStringContainsString( 'gutenberg', $captured_prompt );
+		$this->assertStringContainsString( 'blocks', $captured_prompt );
+		$this->assertStringContainsString( 'rest', $captured_prompt );
+	}
+
+	/**
+	 * Test generate rejects responses missing the description field.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_malformed_response(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'meta' => 'not the right key' )
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_meta_malformed', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects an empty description string.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_empty_description(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'description' => '   ' )
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_meta_empty', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects a description shorter than min length.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_too_short_description(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'description' => 'Too short.' )
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_meta_too_short', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test generate rejects an overly long description.
+	 *
+	 * @return void
+	 */
+	public function test_generate_rejects_too_long_description(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'description' => str_repeat( 'a', 200 ) )
+		);
+
+		$generator = new MetaDescriptionGenerator( $service );
+
+		$result = $generator->generate( 'Body content.' );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_meta_too_long', $result->get_error_codes() );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`MetaDescriptionGenerator\` enhancement handler that produces SEO meta descriptions (50–160 chars) via \`AIService\`
- Accepts optional \`title\` and \`keywords\` (string or array) options to bias the output toward the intended SERP snippet
- 11 PHPUnit tests cover empty content, service errors, malformed/empty/too-short/too-long responses, and prompt content forwarding

Part of epic #8 — one of the remaining enhancement task handlers called out in the technical notes.

## Test plan
- [x] \`./vendor/bin/phpunit --filter MetaDescriptionGeneratorTest\` — 11 tests / 21 assertions
- [x] \`composer run lint\` — PHPCS clean
- [x] \`composer run phpstan\` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered automatic meta description generation. The system validates content, respects character limits, and supports optional title and keyword parameters for improved SEO optimization.

* **Tests**
  * Introduced comprehensive test coverage for the new meta description generation feature, including validation of error handling, character length constraints, and response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->