### PR TITLE
Add ThreadStitcher enhancement handler

### DIFF
--- a/includes/AI/ThreadStitcher.php
+++ b/includes/AI/ThreadStitcher.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Thread stitcher.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Stitches a multi-item social thread (e.g. a Twitter/X thread) into a
+ * single coherent long-form post body via AIService.
+ *
+ * The caller passes the ordered list of items. Each item must have a
+ * non-empty 'text' key. The AI is asked to fuse them into readable
+ * paragraphs without losing meaning, removing the tweet-style numbering
+ * ("1/", "2/", "🧵") while preserving the original voice.
+ */
+class ThreadStitcher {
+
+	/**
+	 * Minimum number of items required to stitch.
+	 */
+	private const MIN_ITEMS = 2;
+
+	/**
+	 * AI service.
+	 *
+	 * @var AIService
+	 */
+	private AIService $service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIService $service AI service wrapper.
+	 */
+	public function __construct( AIService $service ) {
+		$this->service = $service;
+	}
+
+	/**
+	 * Stitch an ordered list of thread items into a single post body.
+	 *
+	 * @param array<int, array<string, mixed>> $items   Ordered thread items. Each requires a 'text' key; 'author'/'created_at' are optional.
+	 * @param array<string, mixed>             $options Options: 'voice' (string) e.g. "first-person casual".
+	 * @return array{body: string, summary: string}|WP_Error Stitched output or error.
+	 */
+	public function stitch( array $items, array $options = array() ) {
+		if ( count( $items ) < self::MIN_ITEMS ) {
+			return new WP_Error(
+				'ai_thread_too_few_items',
+				sprintf(
+					/* translators: %d: minimum items. */
+					__( 'At least %d thread items are required to stitch.', 'ai-importer' ),
+					self::MIN_ITEMS
+				)
+			);
+		}
+
+		$normalized = array();
+		foreach ( $items as $index => $item ) {
+			if ( ! is_array( $item ) || ! isset( $item['text'] ) || ! is_string( $item['text'] ) ) {
+				return new WP_Error(
+					'ai_thread_invalid_item',
+					sprintf(
+						/* translators: %d: item index. */
+						__( 'Thread item at index %d is missing a text field.', 'ai-importer' ),
+						$index
+					)
+				);
+			}
+
+			$text = trim( $item['text'] );
+			if ( '' === $text ) {
+				return new WP_Error(
+					'ai_thread_empty_item',
+					sprintf(
+						/* translators: %d: item index. */
+						__( 'Thread item at index %d has empty text.', 'ai-importer' ),
+						$index
+					)
+				);
+			}
+
+			$normalized[] = $text;
+		}
+
+		$voice  = isset( $options['voice'] ) ? (string) $options['voice'] : '';
+		$prompt = $this->build_prompt( $normalized, $voice );
+		$schema = $this->build_schema();
+
+		$response = $this->service->generate_structured( $prompt, $schema );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( ! array_key_exists( 'body', $response ) || ! is_string( $response['body'] ) ) {
+			return new WP_Error(
+				'ai_thread_malformed',
+				__( 'AI response did not include a body string.', 'ai-importer' ),
+				array( 'response' => $response )
+			);
+		}
+
+		$body = trim( $response['body'] );
+		if ( '' === $body ) {
+			return new WP_Error(
+				'ai_thread_empty_body',
+				__( 'AI returned an empty thread body.', 'ai-importer' )
+			);
+		}
+
+		$summary = isset( $response['summary'] ) && is_string( $response['summary'] )
+			? trim( $response['summary'] )
+			: '';
+
+		return array(
+			'body'    => $body,
+			'summary' => $summary,
+		);
+	}
+
+	/**
+	 * Build the stitching prompt.
+	 *
+	 * @param array<int, string> $texts Ordered item texts.
+	 * @param string             $voice Optional voice hint.
+	 * @return string Prompt.
+	 */
+	private function build_prompt( array $texts, string $voice ): string {
+		$numbered = array();
+		foreach ( $texts as $index => $text ) {
+			$numbered[] = sprintf( '[%d] %s', $index + 1, $text );
+		}
+
+		$prompt = 'You are stitching a social media thread into a coherent long-form post. '
+			. 'Fuse the numbered items below into readable paragraphs that preserve the author\'s meaning and voice. '
+			. 'Remove thread markers like "1/", "2/10", or "🧵". Do not add new claims not present in the source. '
+			. 'Also produce a one-sentence summary.';
+
+		if ( '' !== $voice ) {
+			$prompt .= ' Match this voice: ' . $voice . '.';
+		}
+
+		$prompt .= "\n\nThread items (in order):\n" . implode( "\n", $numbered );
+
+		return $prompt;
+	}
+
+	/**
+	 * JSON schema for the stitched response.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function build_schema(): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'body'    => array(
+					'type'        => 'string',
+					'description' => 'Stitched post body in readable paragraphs.',
+				),
+				'summary' => array(
+					'type'        => 'string',
+					'description' => 'One-sentence summary of the thread.',
+				),
+			),
+			'required'   => array( 'body' ),
+		);
+	}
+}

--- a/tests/Unit/AI/ThreadStitcherTest.php
+++ b/tests/Unit/AI/ThreadStitcherTest.php
@@ -1,0 +1,237 @@
+<?php
+/**
+ * ThreadStitcher class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\ThreadStitcher;
+use AI_Importer\Tests\Unit\TestCase;
+use WP_Error;
+
+/**
+ * Tests for the ThreadStitcher class.
+ */
+class ThreadStitcherTest extends TestCase {
+
+	/**
+	 * Default happy-path items used across tests.
+	 *
+	 * @return array<int, array<string, string>>
+	 */
+	private function sample_items(): array {
+		return array(
+			array( 'text' => '1/ Starting a thread about WordPress 7 AI.' ),
+			array( 'text' => '2/ It ships wp_get_ai_client() out of the box.' ),
+			array( 'text' => '3/ Plugins can use it without a dependency.' ),
+		);
+	}
+
+	/**
+	 * Test stitch returns WP_Error when fewer than two items are provided.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_returns_error_with_too_few_items(): void {
+		$service  = $this->createMock( AIService::class );
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch( array( array( 'text' => 'Only one.' ) ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_thread_too_few_items', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test stitch rejects items missing a text key.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_rejects_items_missing_text(): void {
+		$service  = $this->createMock( AIService::class );
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch(
+			array(
+				array( 'text' => 'First item.' ),
+				array( 'id' => 123 ),
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_thread_invalid_item', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test stitch rejects items with an empty text string.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_rejects_empty_item_text(): void {
+		$service  = $this->createMock( AIService::class );
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch(
+			array(
+				array( 'text' => 'First item.' ),
+				array( 'text' => '   ' ),
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_thread_empty_item', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test stitch propagates AIService errors.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_propagates_service_errors(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			new WP_Error( 'ai_unavailable', 'No provider configured.' )
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch( $this->sample_items() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test stitch returns body and summary on success.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_returns_body_and_summary(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array(
+				'body'    => "Stitched paragraph 1.\n\nStitched paragraph 2.",
+				'summary' => 'A short summary of the thread.',
+			)
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch( $this->sample_items() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( "Stitched paragraph 1.\n\nStitched paragraph 2.", $result['body'] );
+		$this->assertSame( 'A short summary of the thread.', $result['summary'] );
+	}
+
+	/**
+	 * Test stitch returns empty summary when AI omits it.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_tolerates_missing_summary(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'body' => 'Only body, no summary.' )
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch( $this->sample_items() );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 'Only body, no summary.', $result['body'] );
+		$this->assertSame( '', $result['summary'] );
+	}
+
+	/**
+	 * Test stitch includes all item texts in the prompt.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_includes_item_texts_in_prompt(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'body' => 'Stitched.' );
+			}
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+		$stitcher->stitch( $this->sample_items() );
+
+		$this->assertStringContainsString( 'wp_get_ai_client', $captured_prompt );
+		$this->assertStringContainsString( 'without a dependency', $captured_prompt );
+	}
+
+	/**
+	 * Test stitch includes voice option in the prompt.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_includes_voice_option(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $_schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'body' => 'Stitched.' );
+			}
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+		$stitcher->stitch(
+			$this->sample_items(),
+			array( 'voice' => 'first-person casual' )
+		);
+
+		$this->assertStringContainsString( 'first-person casual', $captured_prompt );
+	}
+
+	/**
+	 * Test stitch rejects malformed responses missing body.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_rejects_malformed_response(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'summary' => 'No body field.' )
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch( $this->sample_items() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_thread_malformed', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test stitch rejects an empty body.
+	 *
+	 * @return void
+	 */
+	public function test_stitch_rejects_empty_body(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'body' => '   ' )
+		);
+
+		$stitcher = new ThreadStitcher( $service );
+
+		$result = $stitcher->stitch( $this->sample_items() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_thread_empty_body', $result->get_error_codes() );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`ThreadStitcher\` enhancement handler that fuses an ordered list of social-thread items (e.g. a Twitter/X thread) into a single coherent post body via \`AIService\`
- Validates input up front: requires ≥2 items, each with non-empty \`text\`
- Returns both a stitched \`body\` and a one-sentence \`summary\`
- Accepts an optional \`voice\` hint to preserve author style
- 10 PHPUnit tests cover too-few items, missing/empty text, service errors, malformed/empty-body responses, prompt content forwarding, and optional-summary tolerance

Part of epic #8 — the final enhancement task handler called out in the technical notes. This closes out that checklist line alongside #63 (alt text), #66 (title), #67 (meta description).

## Test plan
- [x] \`./vendor/bin/phpunit --filter ThreadStitcherTest\` — 10 tests / 21 assertions
- [x] \`composer run lint\` — PHPCS clean
- [x] \`composer run phpstan\` — no errors
- [x] Full suite locally on branch: 321 tests, 711 assertions, 0 failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AI-powered thread stitching that combines multiple social items into cohesive long-form posts with automatic summary generation and customizable voice options.

* **Tests**
  * Added comprehensive test coverage for thread stitching, including input validation and error handling verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->