### PR TITLE
Wire TitleGenerator and MetaDescriptionGenerator into import pipeline

### DIFF
--- a/includes/Processor/ImportProcessor.php
+++ b/includes/Processor/ImportProcessor.php
@@ -58,6 +58,13 @@ class ImportProcessor {
 	private MediaHandler $media_handler;
 
 	/**
+	 * Optional AI enhancer.
+	 *
+	 * @var ItemEnhancer|null
+	 */
+	private ?ItemEnhancer $enhancer;
+
+	/**
 	 * Registered normalizers keyed by adapter ID.
 	 *
 	 * @var array<string, ContentNormalizer>|null
@@ -69,10 +76,16 @@ class ImportProcessor {
 	 *
 	 * @param ContentCreator|null $creator       Content creator instance.
 	 * @param MediaHandler|null   $media_handler Media handler instance.
+	 * @param ItemEnhancer|null   $enhancer      Optional AI enhancer.
 	 */
-	public function __construct( ?ContentCreator $creator = null, ?MediaHandler $media_handler = null ) {
+	public function __construct(
+		?ContentCreator $creator = null,
+		?MediaHandler $media_handler = null,
+		?ItemEnhancer $enhancer = null
+	) {
 		$this->creator       = $creator ?? new ContentCreator();
 		$this->media_handler = $media_handler ?? new MediaHandler();
+		$this->enhancer      = $enhancer;
 	}
 
 	/**
@@ -188,6 +201,11 @@ class ImportProcessor {
 			try {
 				$raw_item   = $adapter->fetch_item( $item_id );
 				$normalized = $normalizer->normalize( $raw_item );
+
+				// Apply AI enhancements (non-fatal failures handled inside).
+				if ( null !== $this->enhancer ) {
+					$this->enhancer->enhance( $normalized );
+				}
 
 				// Sideload media (failures are non-fatal).
 				$media_errors = $this->media_handler->process( $normalized );

--- a/includes/Processor/ItemEnhancer.php
+++ b/includes/Processor/ItemEnhancer.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Item enhancer.
+ *
+ * @package AI_Importer\Processor
+ */
+
+namespace AI_Importer\Processor;
+
+use AI_Importer\AI\MetaDescriptionGenerator;
+use AI_Importer\AI\TitleGenerator;
+use AI_Importer\Normalizer\NormalizedItem;
+
+/**
+ * Applies AI enhancements to a NormalizedItem before it becomes a WordPress post.
+ *
+ * Currently supports title generation (for source items with no native title,
+ * e.g. tweets) and SEO meta description generation. Enhancement failures are
+ * non-fatal — they are logged when WP_DEBUG is on but never stop the import.
+ *
+ * Alt text, hashtag mapping, and thread stitching are handled elsewhere in
+ * the pipeline because they operate on media or pre-normalization input.
+ */
+class ItemEnhancer {
+
+	/**
+	 * Metadata key for the AI-generated SEO description on the normalized item.
+	 */
+	public const META_KEY_SEO_DESCRIPTION = 'seo_description';
+
+	/**
+	 * Title generator.
+	 *
+	 * @var TitleGenerator
+	 */
+	private TitleGenerator $title_generator;
+
+	/**
+	 * Meta description generator.
+	 *
+	 * @var MetaDescriptionGenerator
+	 */
+	private MetaDescriptionGenerator $meta_generator;
+
+	/**
+	 * Enhancement flags.
+	 *
+	 * @var array{title: bool, meta_description: bool}
+	 */
+	private array $flags;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param TitleGenerator           $title_generator Title generator.
+	 * @param MetaDescriptionGenerator $meta_generator  Meta description generator.
+	 * @param array<string, bool>      $flags           Optional per-enhancement flags: 'title', 'meta_description'.
+	 */
+	public function __construct(
+		TitleGenerator $title_generator,
+		MetaDescriptionGenerator $meta_generator,
+		array $flags = array()
+	) {
+		$this->title_generator = $title_generator;
+		$this->meta_generator  = $meta_generator;
+		$this->flags           = array(
+			'title'            => (bool) ( $flags['title'] ?? true ),
+			'meta_description' => (bool) ( $flags['meta_description'] ?? true ),
+		);
+	}
+
+	/**
+	 * Apply enabled enhancements to the item in place.
+	 *
+	 * @param NormalizedItem $item Item to enhance (mutated).
+	 * @return void
+	 */
+	public function enhance( NormalizedItem $item ): void {
+		if ( $this->flags['title'] ) {
+			$this->enhance_title( $item );
+		}
+
+		if ( $this->flags['meta_description'] ) {
+			$this->enhance_meta_description( $item );
+		}
+	}
+
+	/**
+	 * Generate a title when the item has none.
+	 *
+	 * @param NormalizedItem $item Item (mutated).
+	 * @return void
+	 */
+	private function enhance_title( NormalizedItem $item ): void {
+		if ( null !== $item->title && '' !== trim( $item->title ) ) {
+			return;
+		}
+
+		if ( '' === trim( $item->content ) ) {
+			return;
+		}
+
+		$result = $this->title_generator->generate( $item->content );
+
+		if ( is_wp_error( $result ) ) {
+			$this->log_failure( 'title', $item->source_id, $this->first_message( $result ) );
+			return;
+		}
+
+		$item->title = $result;
+	}
+
+	/**
+	 * Generate an SEO meta description and stash it in $item->metadata.
+	 *
+	 * @param NormalizedItem $item Item (mutated).
+	 * @return void
+	 */
+	private function enhance_meta_description( NormalizedItem $item ): void {
+		if ( '' === trim( $item->content ) ) {
+			return;
+		}
+
+		$options = array();
+		if ( null !== $item->title && '' !== trim( $item->title ) ) {
+			$options['title'] = $item->title;
+		}
+
+		if ( ! empty( $item->tags ) ) {
+			$options['keywords'] = $item->tags;
+		}
+
+		$result = $this->meta_generator->generate( $item->content, $options );
+
+		if ( is_wp_error( $result ) ) {
+			$this->log_failure( 'meta_description', $item->source_id, $this->first_message( $result ) );
+			return;
+		}
+
+		$item->metadata[ self::META_KEY_SEO_DESCRIPTION ] = $result;
+	}
+
+	/**
+	 * Extract the first error message from a WP_Error for logging.
+	 *
+	 * @param \WP_Error $error Error.
+	 * @return string First message or empty string.
+	 */
+	private function first_message( \WP_Error $error ): string {
+		$messages = $error->get_error_messages();
+
+		return is_array( $messages ) && ! empty( $messages ) ? (string) $messages[0] : '';
+	}
+
+	/**
+	 * Log a non-fatal enhancement failure (debug only).
+	 *
+	 * @param string $kind      Enhancement kind.
+	 * @param string $source_id Source item ID.
+	 * @param string $message   Error message.
+	 * @return void
+	 */
+	private function log_failure( string $kind, string $source_id, string $message ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log -- Debug-only diagnostic log.
+			error_log(
+				sprintf(
+					'[ai-importer] %s enhancement failed for item %s: %s',
+					$kind,
+					$source_id,
+					$message
+				)
+			);
+		}
+	}
+}

--- a/tests/Unit/Processor/ImportProcessorTest.php
+++ b/tests/Unit/Processor/ImportProcessorTest.php
@@ -15,6 +15,7 @@ use AI_Importer\Normalizer\ContentNormalizer;
 use AI_Importer\Normalizer\NormalizedItem;
 use AI_Importer\Processor\ContentCreator;
 use AI_Importer\Processor\ImportProcessor;
+use AI_Importer\Processor\ItemEnhancer;
 use AI_Importer\Processor\MediaHandler;
 use AI_Importer\Schema\SettingsSchema;
 use AI_Importer\Tests\Unit\TestCase;
@@ -352,6 +353,38 @@ class ImportProcessorTest extends TestCase {
 		);
 
 		AdapterRegistry::get_instance()->register( $adapter );
+	}
+
+	/**
+	 * Test process_batch invokes the enhancer on every normalized item when supplied.
+	 *
+	 * @return void
+	 */
+	public function test_process_batch_invokes_enhancer_when_provided(): void {
+		$this->register_mock_adapter();
+
+		$creator = Mockery::mock( ContentCreator::class );
+		$creator->shouldReceive( 'create' )->andReturn( 200, 201 );
+
+		$media_handler = Mockery::mock( MediaHandler::class );
+		$media_handler->shouldReceive( 'process' )->andReturn( array() );
+
+		$normalizer = $this->create_mock_normalizer();
+
+		Filters\expectApplied( 'ai_importer_normalizers' )
+			->andReturn( array( 'twitter' => $normalizer ) );
+
+		$enhancer = Mockery::mock( ItemEnhancer::class );
+		$enhancer->shouldReceive( 'enhance' )->twice();
+
+		$this->store_batch( 'batch-1', 'processing', array( 'item-1', 'item-2' ) );
+
+		$processor = new ImportProcessor( $creator, $media_handler, $enhancer );
+		$processor->process_batch( 'batch-1' );
+
+		$batch = $this->options['ai_importer_batch_batch-1'];
+		$this->assertSame( 'completed', $batch['state'] );
+		$this->assertSame( 2, $batch['processed'] );
 	}
 
 	/**

--- a/tests/Unit/Processor/ItemEnhancerTest.php
+++ b/tests/Unit/Processor/ItemEnhancerTest.php
@@ -1,0 +1,289 @@
+<?php
+/**
+ * ItemEnhancer class tests.
+ *
+ * @package AI_Importer\Tests\Unit\Processor
+ */
+
+namespace AI_Importer\Tests\Unit\Processor;
+
+use AI_Importer\AI\MetaDescriptionGenerator;
+use AI_Importer\AI\TitleGenerator;
+use AI_Importer\Adapters\Manifest\ContentType;
+use AI_Importer\Normalizer\NormalizedItem;
+use AI_Importer\Processor\ItemEnhancer;
+use AI_Importer\Tests\Unit\TestCase;
+use DateTimeImmutable;
+use WP_Error;
+
+/**
+ * Tests for the ItemEnhancer class.
+ */
+class ItemEnhancerTest extends TestCase {
+
+	/**
+	 * Build a minimal NormalizedItem for tests.
+	 *
+	 * @param string|null $title   Title.
+	 * @param string      $content Content.
+	 * @return NormalizedItem
+	 */
+	private function make_item( ?string $title, string $content, array $tags = array() ): NormalizedItem {
+		return new NormalizedItem(
+			source_id: 'src-1',
+			source_adapter: 'twitter',
+			content_type: ContentType::POST,
+			content: $content,
+			publish_date: new DateTimeImmutable( '2026-04-01T00:00:00Z' ),
+			title: $title,
+			tags: $tags,
+		);
+	}
+
+	/**
+	 * Test enhance assigns a generated title when the item has none.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_sets_title_when_missing(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->expects( $this->once() )
+			->method( 'generate' )
+			->willReturn( 'A generated title' );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( null, 'Some tweet content that needs a title.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertSame( 'A generated title', $item->title );
+	}
+
+	/**
+	 * Test enhance leaves an existing title alone.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_preserves_existing_title(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->expects( $this->never() )->method( 'generate' );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( 'My existing title', 'Body content.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertSame( 'My existing title', $item->title );
+	}
+
+	/**
+	 * Test enhance treats whitespace-only title as missing.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_treats_whitespace_title_as_missing(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->expects( $this->once() )
+			->method( 'generate' )
+			->willReturn( 'Generated title' );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( '   ', 'Body content.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertSame( 'Generated title', $item->title );
+	}
+
+	/**
+	 * Test enhance skips title generation when content is empty.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_skips_title_when_content_empty(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->expects( $this->never() )->method( 'generate' );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( null, '   ' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertNull( $item->title );
+	}
+
+	/**
+	 * Test enhance tolerates a title generator failure silently.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_title_failure_is_non_fatal(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->method( 'generate' )->willReturn(
+			new WP_Error( 'ai_title_too_long', 'Title too long.' )
+		);
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( null, 'Body content.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertNull( $item->title );
+	}
+
+	/**
+	 * Test enhance stores the generated SEO description in metadata.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_stores_meta_description(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->expects( $this->once() )
+			->method( 'generate' )
+			->willReturn( 'A 100-ish character SEO description that fits within typical SERP snippet windows and reads well.' );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( 'My title', 'Body content for the post.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertArrayHasKey( ItemEnhancer::META_KEY_SEO_DESCRIPTION, $item->metadata );
+		$this->assertSame(
+			'A 100-ish character SEO description that fits within typical SERP snippet windows and reads well.',
+			$item->metadata[ ItemEnhancer::META_KEY_SEO_DESCRIPTION ]
+		);
+	}
+
+	/**
+	 * Test enhance forwards title and tags to the meta description generator.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_forwards_context_to_meta_generator(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$captured_options = null;
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturnCallback(
+			function ( $_content, $options ) use ( &$captured_options ) {
+				$captured_options = $options;
+
+				return 'A 100-ish character SEO description that fits within typical SERP snippet windows and reads well.';
+			}
+		);
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( 'My title', 'Body content.', array( 'wordpress', 'ai' ) );
+
+		$enhancer->enhance( $item );
+
+		$this->assertSame( 'My title', $captured_options['title'] );
+		$this->assertSame( array( 'wordpress', 'ai' ), $captured_options['keywords'] );
+	}
+
+	/**
+	 * Test enhance skips meta description when content is empty.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_skips_meta_when_content_empty(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->expects( $this->never() )->method( 'generate' );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( 'Title', '   ' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertArrayNotHasKey( ItemEnhancer::META_KEY_SEO_DESCRIPTION, $item->metadata );
+	}
+
+	/**
+	 * Test enhance tolerates a meta generator failure silently.
+	 *
+	 * @return void
+	 */
+	public function test_enhance_meta_failure_is_non_fatal(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn(
+			new WP_Error( 'ai_meta_too_short', 'Too short.' )
+		);
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen );
+		$item     = $this->make_item( 'Title', 'Body content.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertArrayNotHasKey( ItemEnhancer::META_KEY_SEO_DESCRIPTION, $item->metadata );
+	}
+
+	/**
+	 * Test disabled title flag skips title generation.
+	 *
+	 * @return void
+	 */
+	public function test_title_flag_disables_title_generation(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->expects( $this->never() )->method( 'generate' );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$enhancer = new ItemEnhancer( $title_gen, $meta_gen, array( 'title' => false ) );
+		$item     = $this->make_item( null, 'Body content.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertNull( $item->title );
+	}
+
+	/**
+	 * Test disabled meta flag skips meta description generation.
+	 *
+	 * @return void
+	 */
+	public function test_meta_flag_disables_meta_generation(): void {
+		$title_gen = $this->createMock( TitleGenerator::class );
+		$title_gen->method( 'generate' )->willReturn( new WP_Error( 'skip', 'skip' ) );
+
+		$meta_gen = $this->createMock( MetaDescriptionGenerator::class );
+		$meta_gen->expects( $this->never() )->method( 'generate' );
+
+		$enhancer = new ItemEnhancer(
+			$title_gen,
+			$meta_gen,
+			array( 'meta_description' => false )
+		);
+		$item = $this->make_item( 'Title', 'Body content.' );
+
+		$enhancer->enhance( $item );
+
+		$this->assertArrayNotHasKey( ItemEnhancer::META_KEY_SEO_DESCRIPTION, $item->metadata );
+	}
+}


### PR DESCRIPTION
## Summary
- Adds \`ItemEnhancer\` in the Processor layer that applies AI-driven title generation (for source items with no native title, e.g. tweets) and SEO meta description generation to a \`NormalizedItem\` just after normalization and before media sideload
- Title is assigned directly to \`NormalizedItem::title\` when missing; meta description is stored in \`NormalizedItem::metadata['seo_description']\` for ContentCreator (or a future Yoast/Rank Math integration) to persist as post meta
- Per-enhancement flags (\`title\`, \`meta_description\`) allow disabling each independently
- Enhancement failures are non-fatal and logged only under \`WP_DEBUG\`, so AI outages never break imports
- \`ImportProcessor\` now accepts an optional \`ItemEnhancer\` — null default keeps the pipeline backward compatible

Part of epic #13 (F5 Basic Enhancements). Companion to the handler PRs (#63, #66, #67, #68) that delivered the underlying generators.

Out of scope for this PR (follow-up work):
- Alt text wiring — needs post-sideload integration with \`MediaHandler\`
- Thread stitching wiring — runs pre-normalization, not per-item
- Batch-level \`enhancements\` setting schema in \`ImportsController\` + \`SettingsSchema\`
- Post meta save for \`seo_description\` in \`ContentCreator\`

## Test plan
- [x] \`./vendor/bin/phpunit --filter ItemEnhancerTest\` — 11 tests / 21 assertions
- [x] \`./vendor/bin/phpunit --filter ImportProcessorTest\` — 11 tests / 23 assertions (1 new, 10 existing still pass with optional dependency)
- [x] Full suite: 352 tests / 768 assertions / 0 failures
- [x] \`composer run lint\` — PHPCS clean
- [x] \`composer run phpstan\` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced import process with optional automatic title generation for items without titles and automatic SEO description generation during batch processing.

* **Tests**
  * Added comprehensive unit tests for new enhancement capabilities and integration with import processor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->