### PR TITLE
Persist AI-generated SEO description as post meta

### DIFF
--- a/includes/Processor/ContentCreator.php
+++ b/includes/Processor/ContentCreator.php
@@ -43,6 +43,11 @@ class ContentCreator {
 	public const META_IMPORTED_AT = '_ai_importer_imported_at';
 
 	/**
+	 * Post meta key for the AI-generated SEO meta description.
+	 */
+	public const META_SEO_DESCRIPTION = '_ai_importer_seo_description';
+
+	/**
 	 * Create a WordPress post from a normalized item.
 	 *
 	 * @param NormalizedItem $item     The normalized content.
@@ -90,6 +95,14 @@ class ContentCreator {
 
 		if ( $item->source_url ) {
 			update_post_meta( $post_id, self::META_ORIGINAL_URL, $item->source_url );
+		}
+
+		$seo_key = ItemEnhancer::META_KEY_SEO_DESCRIPTION;
+		if ( isset( $item->metadata[ $seo_key ] )
+			&& is_string( $item->metadata[ $seo_key ] )
+			&& '' !== $item->metadata[ $seo_key ]
+		) {
+			update_post_meta( $post_id, self::META_SEO_DESCRIPTION, $item->metadata[ $seo_key ] );
 		}
 
 		// Set tags from hashtags.

--- a/tests/Unit/Processor/ContentCreatorTest.php
+++ b/tests/Unit/Processor/ContentCreatorTest.php
@@ -11,6 +11,7 @@ use AI_Importer\Adapters\Manifest\ContentType;
 use AI_Importer\Normalizer\MediaReference;
 use AI_Importer\Normalizer\NormalizedItem;
 use AI_Importer\Processor\ContentCreator;
+use AI_Importer\Processor\ItemEnhancer;
 use AI_Importer\Tests\Unit\TestCase;
 use Brain\Monkey\Actions;
 use Brain\Monkey\Functions;
@@ -155,6 +156,66 @@ class ContentCreatorTest extends TestCase {
 		$this->creator->create( $this->make_item(), 'batch-abc' );
 
 		$this->assertBrainMonkeyExpectations();
+	}
+
+	/**
+	 * Test the SEO description meta is persisted when present on the item.
+	 *
+	 * @return void
+	 */
+	public function test_seo_description_meta_persisted(): void {
+		$item = $this->make_item(
+			array(
+				'metadata' => array(
+					ItemEnhancer::META_KEY_SEO_DESCRIPTION => 'Concise SEO-friendly summary that describes the post for SERPs.',
+				),
+			)
+		);
+
+		$this->creator->create( $item, 'batch-abc' );
+
+		$this->assertSame(
+			'Concise SEO-friendly summary that describes the post for SERPs.',
+			$this->post_meta[42][ ContentCreator::META_SEO_DESCRIPTION ]
+		);
+	}
+
+	/**
+	 * Test the SEO description meta is not set when absent.
+	 *
+	 * @return void
+	 */
+	public function test_seo_description_meta_not_set_when_absent(): void {
+		$item = $this->make_item();
+
+		$this->creator->create( $item, 'batch-abc' );
+
+		$this->assertArrayNotHasKey(
+			ContentCreator::META_SEO_DESCRIPTION,
+			$this->post_meta[42] ?? array()
+		);
+	}
+
+	/**
+	 * Test the SEO description meta is not set when empty string.
+	 *
+	 * @return void
+	 */
+	public function test_seo_description_meta_not_set_when_empty(): void {
+		$item = $this->make_item(
+			array(
+				'metadata' => array(
+					ItemEnhancer::META_KEY_SEO_DESCRIPTION => '',
+				),
+			)
+		);
+
+		$this->creator->create( $item, 'batch-abc' );
+
+		$this->assertArrayNotHasKey(
+			ContentCreator::META_SEO_DESCRIPTION,
+			$this->post_meta[42] ?? array()
+		);
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- \`ContentCreator\` now persists \`NormalizedItem::metadata['seo_description']\` to the new \`_ai_importer_seo_description\` post meta key
- Closes the loop on the meta description side of #69: generator builds it → enhancer stashes it → creator persists it
- Themes and SEO plugins can read the meta key directly (or a future integration can filter it into Yoast / Rank Math keys)

Part of epic #13 (F5 Basic Enhancements).

## Test plan
- [x] \`./vendor/bin/phpunit --filter ContentCreatorTest\` — 9 tests / 12 assertions (3 new for presence / absence / empty-string cases)
- [x] Full suite: 355 tests / 771 assertions / 0 failures
- [x] \`composer run lint\` — PHPCS clean
- [x] \`composer run phpstan\` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The importer now automatically captures and persists AI-generated SEO meta descriptions during the content import process, enhancing search engine optimization for imported content.

## Tests
* Added unit tests to verify SEO description metadata is correctly written when present and properly handled when absent or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->