### PR TITLE
Bootstrap ItemEnhancer in Plugin init so it runs in real imports

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -9,7 +9,11 @@ namespace AI_Importer;
 
 use AI_Importer\Adapters\AdapterRegistry;
 use AI_Importer\Adapters\TwitterAdapter;
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\MetaDescriptionGenerator;
+use AI_Importer\AI\TitleGenerator;
 use AI_Importer\Processor\ImportProcessor;
+use AI_Importer\Processor\ItemEnhancer;
 use AI_Importer\REST\ImportsController;
 use AI_Importer\REST\SourcesController;
 
@@ -81,7 +85,7 @@ class Plugin {
 		do_action( 'ai_importer_register_adapters', $this->adapter_registry );
 
 		// Initialize import processor (must run on all requests for Action Scheduler).
-		$processor = new ImportProcessor();
+		$processor = new ImportProcessor( null, null, $this->build_item_enhancer() );
 		$processor->init();
 
 		// Initialize admin.
@@ -123,5 +127,39 @@ class Plugin {
 	 */
 	public function get_adapter_registry(): ?AdapterRegistry {
 		return $this->adapter_registry;
+	}
+
+	/**
+	 * Construct the AI-backed item enhancer when a provider is available.
+	 *
+	 * Returns null when no WP AI client is configured so the processor
+	 * runs without enhancement instead of emitting per-item errors.
+	 *
+	 * @return ItemEnhancer|null
+	 */
+	private function build_item_enhancer(): ?ItemEnhancer {
+		$service = new AIService();
+
+		if ( ! $service->is_available() ) {
+			$enhancer = null;
+		} else {
+			$enhancer = new ItemEnhancer(
+				new TitleGenerator( $service ),
+				new MetaDescriptionGenerator( $service )
+			);
+		}
+
+		/**
+		 * Filters the item enhancer used by the import processor.
+		 *
+		 * Return null to disable AI enhancements entirely. Return a custom
+		 * ItemEnhancer instance to override title and meta description flags
+		 * or to inject alternative generators.
+		 *
+		 * @param ItemEnhancer|null $enhancer Default enhancer (null when AI is unavailable).
+		 */
+		$filtered = apply_filters( 'ai_importer_item_enhancer', $enhancer );
+
+		return $filtered instanceof ItemEnhancer ? $filtered : null;
 	}
 }

--- a/tests/Unit/PluginTest.php
+++ b/tests/Unit/PluginTest.php
@@ -33,6 +33,10 @@ class PluginTest extends TestCase {
 
 		// Reset the adapter registry so built-in adapters can re-register.
 		AdapterRegistry::get_instance()->reset();
+
+		// Ensure the AI client probe is inert so Plugin::init() doesn't
+		// construct an ItemEnhancer and call into an unstubbed provider.
+		Functions\when( 'wp_get_ai_client' )->justReturn( null );
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- \`Plugin::init()\` now constructs an \`AIService\` probe, builds \`TitleGenerator\` + \`MetaDescriptionGenerator\`, and passes them to \`ImportProcessor\` via a new \`ItemEnhancer\`
- When \`AIService::is_available()\` returns false (no WP AI client configured), the enhancer is null and the pipeline runs exactly as before
- Adds the \`ai_importer_item_enhancer\` filter so other plugins can swap in a custom enhancer, tweak per-enhancement flags, or disable AI enhancements entirely by returning null
- \`PluginTest::set_up()\` stubs \`wp_get_ai_client\` so the suite stays hermetic across tests that do/don't define it

Completes the activation side of epic #13 (F5 Basic Enhancements) — without this, #69 and #70 were wired but never ran in production.

## Test plan
- [x] Full suite: 352 tests / 768 assertions / 0 failures
- [x] \`composer run lint\` — PHPCS clean
- [x] \`composer run phpstan\` — no errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an extensibility filter hook to enable custom control over AI-powered enhancement behavior during content imports.

* **Bug Fixes**
  * AI-enhanced features now gracefully handle unavailable providers, automatically disabling when the AI service is inaccessible.

* **Tests**
  * Improved unit test reliability by properly stubbing AI provider interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->