### PR TITLE
Add HashtagMapper enhancement handler (F5.3)

### DIFF
--- a/includes/AI/HashtagMapper.php
+++ b/includes/AI/HashtagMapper.php
@@ -1,0 +1,206 @@
+<?php
+/**
+ * Hashtag-to-WordPress-tag mapper.
+ *
+ * @package AI_Importer\AI
+ */
+
+namespace AI_Importer\AI;
+
+use WP_Error;
+
+/**
+ * Maps a batch of raw source hashtags into clean, WordPress-friendly tag names.
+ *
+ * Source platforms generally emit hashtags as packed tokens
+ * (e.g. "ClimateChange", "wordpress_7_launch"). This mapper asks the AI
+ * to normalize them in a single batch call: expand CamelCase, strip
+ * punctuation, consolidate near-duplicates, and drop nonsense
+ * tokens that would pollute the site's tag taxonomy.
+ */
+class HashtagMapper {
+
+	/**
+	 * Default maximum number of output tags.
+	 */
+	private const DEFAULT_MAX_TAGS = 10;
+
+	/**
+	 * Minimum length for an input hashtag to be considered valid.
+	 */
+	private const MIN_INPUT_LENGTH = 2;
+
+	/**
+	 * AI service.
+	 *
+	 * @var AIService
+	 */
+	private AIService $service;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param AIService $service AI service wrapper.
+	 */
+	public function __construct( AIService $service ) {
+		$this->service = $service;
+	}
+
+	/**
+	 * Map a list of raw hashtags into cleaned WordPress tag names.
+	 *
+	 * @param array<string>        $hashtags Raw hashtags (with or without leading #).
+	 * @param array<string, mixed> $options  Options: 'context' (string), 'max_tags' (int).
+	 * @return array<string>|WP_Error Array of cleaned tag names or error.
+	 */
+	public function map( array $hashtags, array $options = array() ) {
+		$normalized = $this->normalize_input( $hashtags );
+
+		if ( empty( $normalized ) ) {
+			return new WP_Error(
+				'ai_hashtag_empty',
+				__( 'No valid hashtags supplied for mapping.', 'ai-importer' )
+			);
+		}
+
+		$max_tags = isset( $options['max_tags'] ) ? max( 1, (int) $options['max_tags'] ) : self::DEFAULT_MAX_TAGS;
+		$context  = isset( $options['context'] ) ? (string) $options['context'] : '';
+
+		$prompt = $this->build_prompt( $normalized, $context, $max_tags );
+		$schema = $this->build_schema( $max_tags );
+
+		$response = $this->service->generate_structured( $prompt, $schema );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		if ( ! array_key_exists( 'tags', $response ) || ! is_array( $response['tags'] ) ) {
+			return new WP_Error(
+				'ai_hashtag_malformed',
+				__( 'AI response did not include a tags array.', 'ai-importer' ),
+				array( 'response' => $response )
+			);
+		}
+
+		$tags = array();
+		$seen = array();
+		foreach ( $response['tags'] as $raw ) {
+			if ( ! is_string( $raw ) ) {
+				return new WP_Error(
+					'ai_hashtag_malformed',
+					__( 'AI response contained a non-string tag value.', 'ai-importer' ),
+					array( 'response' => $response )
+				);
+			}
+
+			$tag = trim( $raw );
+			if ( '' === $tag ) {
+				continue;
+			}
+
+			$key = strtolower( $tag );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+
+			$tags[] = $tag;
+
+			if ( count( $tags ) >= $max_tags ) {
+				break;
+			}
+		}
+
+		return $tags;
+	}
+
+	/**
+	 * Normalize and deduplicate the input hashtag list.
+	 *
+	 * Strips a leading '#', drops entries that are empty, too short, or
+	 * purely numeric, and deduplicates case-insensitively.
+	 *
+	 * @param array<string> $hashtags Raw input.
+	 * @return array<string> Normalized tokens, preserving input order.
+	 */
+	private function normalize_input( array $hashtags ): array {
+		$out  = array();
+		$seen = array();
+
+		foreach ( $hashtags as $raw ) {
+			if ( ! is_string( $raw ) ) {
+				continue;
+			}
+
+			$token = ltrim( trim( $raw ), '#' );
+			$token = trim( $token );
+
+			if ( '' === $token || mb_strlen( $token ) < self::MIN_INPUT_LENGTH ) {
+				continue;
+			}
+
+			if ( ctype_digit( $token ) ) {
+				continue;
+			}
+
+			$key = strtolower( $token );
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+
+			$out[] = $token;
+		}
+
+		return $out;
+	}
+
+	/**
+	 * Build the prompt for hashtag mapping.
+	 *
+	 * @param array<string> $hashtags Normalized hashtag tokens.
+	 * @param string        $context  Optional post context.
+	 * @param int           $max_tags Maximum tags to return.
+	 * @return string Prompt.
+	 */
+	private function build_prompt( array $hashtags, string $context, int $max_tags ): string {
+		$prompt  = sprintf(
+			'Convert the following social-media hashtags into a clean list of WordPress tag names. '
+			. 'Expand CamelCase and snake_case into properly spaced words, use title case where '
+			. 'appropriate, consolidate near-duplicates, and drop tokens that are nonsense or too '
+			. 'narrow to be useful as a site taxonomy term. Return no more than %d tags.',
+			$max_tags
+		);
+		$prompt .= "\n\nHashtags:\n- " . implode( "\n- ", $hashtags );
+
+		if ( '' !== trim( $context ) ) {
+			$prompt .= "\n\nSurrounding post context:\n" . $context;
+		}
+
+		return $prompt;
+	}
+
+	/**
+	 * JSON schema for the mapper response.
+	 *
+	 * @param int $max_tags Maximum tags.
+	 * @return array<string, mixed>
+	 */
+	private function build_schema( int $max_tags ): array {
+		return array(
+			'type'       => 'object',
+			'properties' => array(
+				'tags' => array(
+					'type'        => 'array',
+					'description' => 'Cleaned WordPress tag names.',
+					'maxItems'    => $max_tags,
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
+			),
+			'required'   => array( 'tags' ),
+		);
+	}
+}

--- a/tests/Unit/AI/HashtagMapperTest.php
+++ b/tests/Unit/AI/HashtagMapperTest.php
@@ -1,0 +1,251 @@
+<?php
+/**
+ * HashtagMapper class tests.
+ *
+ * @package AI_Importer\Tests\Unit\AI
+ */
+
+namespace AI_Importer\Tests\Unit\AI;
+
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\HashtagMapper;
+use AI_Importer\Tests\Unit\TestCase;
+use WP_Error;
+
+/**
+ * Tests for the HashtagMapper class.
+ */
+class HashtagMapperTest extends TestCase {
+
+	/**
+	 * Test map returns WP_Error when no hashtags are supplied.
+	 *
+	 * @return void
+	 */
+	public function test_map_returns_error_when_input_is_empty(): void {
+		$service = $this->createMock( AIService::class );
+		$mapper  = new HashtagMapper( $service );
+
+		$result = $mapper->map( array() );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_hashtag_empty', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test map returns WP_Error when all hashtags are filtered out as invalid.
+	 *
+	 * @return void
+	 */
+	public function test_map_returns_error_when_all_hashtags_invalid(): void {
+		$service = $this->createMock( AIService::class );
+		$mapper  = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#', '  ', '#a', '123' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_hashtag_empty', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test map propagates AIService errors.
+	 *
+	 * @return void
+	 */
+	public function test_map_propagates_service_errors(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			new WP_Error( 'ai_unavailable', 'No provider configured.' )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#ClimateChange', '#WordPress' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test map returns cleaned tags on success.
+	 *
+	 * @return void
+	 */
+	public function test_map_returns_cleaned_tags(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'tags' => array( 'Climate Change', 'WordPress' ) )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#ClimateChange', '#WordPress' ) );
+
+		$this->assertSame( array( 'Climate Change', 'WordPress' ), $result );
+	}
+
+	/**
+	 * Test map strips leading # before sending hashtags in the prompt.
+	 *
+	 * @return void
+	 */
+	public function test_map_strips_leading_hash_in_prompt(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'tags' => array( 'Climate Change' ) );
+			}
+		);
+
+		$mapper = new HashtagMapper( $service );
+		$mapper->map( array( '#ClimateChange' ) );
+
+		$this->assertStringContainsString( 'ClimateChange', $captured_prompt );
+		$this->assertStringNotContainsString( '#ClimateChange', $captured_prompt );
+	}
+
+	/**
+	 * Test map deduplicates input hashtags case-insensitively.
+	 *
+	 * @return void
+	 */
+	public function test_map_deduplicates_input_case_insensitively(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'tags' => array( 'WordPress' ) );
+			}
+		);
+
+		$mapper = new HashtagMapper( $service );
+		$mapper->map( array( '#ClimateChange', '#climatechange', '#CLIMATECHANGE' ) );
+
+		$this->assertSame( 1, substr_count( strtolower( $captured_prompt ), 'climatechange' ) );
+	}
+
+	/**
+	 * Test map rejects a malformed response that lacks the tags array.
+	 *
+	 * @return void
+	 */
+	public function test_map_rejects_malformed_response(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'result' => 'nope' )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#ClimateChange' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_hashtag_malformed', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test map rejects a response where the tags field is not an array of strings.
+	 *
+	 * @return void
+	 */
+	public function test_map_rejects_response_with_non_string_tags(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'tags' => array( 'WordPress', 42, null ) )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#WordPress' ) );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_hashtag_malformed', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test map filters empty strings out of a valid response.
+	 *
+	 * @return void
+	 */
+	public function test_map_filters_empty_strings_from_response(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'tags' => array( 'WordPress', '   ', 'Climate Change', '' ) )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#WordPress', '#ClimateChange' ) );
+
+		$this->assertSame( array( 'WordPress', 'Climate Change' ), $result );
+	}
+
+	/**
+	 * Test map caps the returned tags at the configured max.
+	 *
+	 * @return void
+	 */
+	public function test_map_caps_tags_at_max(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'tags' => array( 'A', 'B', 'C', 'D', 'E' ) )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#alpha', '#bravo', '#charlie', '#delta', '#echo' ), array( 'max_tags' => 3 ) );
+
+		$this->assertSame( array( 'A', 'B', 'C' ), $result );
+	}
+
+	/**
+	 * Test map includes post context in the prompt when provided.
+	 *
+	 * @return void
+	 */
+	public function test_map_includes_context_in_prompt(): void {
+		$captured_prompt = null;
+
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturnCallback(
+			function ( $prompt, $schema ) use ( &$captured_prompt ) {
+				$captured_prompt = $prompt;
+
+				return array( 'tags' => array( 'WordPress' ) );
+			}
+		);
+
+		$mapper = new HashtagMapper( $service );
+		$mapper->map(
+			array( '#WordPress' ),
+			array( 'context' => 'Post about the WordPress 7 launch.' )
+		);
+
+		$this->assertStringContainsString( 'WordPress 7 launch', $captured_prompt );
+	}
+
+	/**
+	 * Test map returns empty array when the AI returns an empty tags list.
+	 *
+	 * @return void
+	 */
+	public function test_map_returns_empty_array_when_ai_returns_no_tags(): void {
+		$service = $this->createMock( AIService::class );
+		$service->method( 'generate_structured' )->willReturn(
+			array( 'tags' => array() )
+		);
+
+		$mapper = new HashtagMapper( $service );
+
+		$result = $mapper->map( array( '#wordpress' ) );
+
+		$this->assertSame( array(), $result );
+	}
+}


### PR DESCRIPTION
## Summary
- Implements **F5.3** of epic #13 — batch-map raw source hashtags into clean, WordPress-friendly tag names in a single AI call.
- Input normalization strips leading `#`, drops empty/too-short/numeric tokens, and deduplicates case-insensitively.
- Response validation rejects missing or non-array `tags` fields, flags non-string items as malformed, trims/dedups/caps output at `max_tags` (default 10).
- Optional `context` option forwards surrounding post text so the model can make better mapping decisions.

## Scope note
Per the established pattern, this PR only ships the handler. Wiring into `ItemEnhancer` (so the mapper runs on \`NormalizedItem->tags\` during import) will be a follow-up.

## Test plan
- [x] \`./vendor/bin/phpunit --filter HashtagMapper\` — 12 tests, 18 assertions pass
- [x] Full suite: 367 tests pass
- [x] \`composer run lint\` clean on new files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added AI-powered hashtag mapping that automatically normalizes, deduplicates, and cleans hashtags into WordPress tag names with configurable limits and optional context support for improved accuracy.

* **Tests**
  * Added comprehensive unit test coverage validating hashtag mapping behavior, including error handling, deduplication, and response validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->