### PR TITLE
Add ContentCleaner for platform cruft removal (F5.4)

### DIFF
--- a/includes/Processor/ContentCleaner.php
+++ b/includes/Processor/ContentCleaner.php
@@ -90,12 +90,16 @@ class ContentCleaner {
 	/**
 	 * Remove standalone short-URL occurrences.
 	 *
+	 * Only matches bare URLs in text. The negative lookbehind preserves URLs
+	 * inside HTML attributes (e.g. `<a href="https://t.co/abc">`) — those are
+	 * intentional links, not platform cruft.
+	 *
 	 * @param string $content Content.
 	 * @return string Content with short URLs removed.
 	 */
 	private function strip_short_urls( string $content ): string {
 		$hosts   = array_map( 'preg_quote', self::SHORT_URL_HOSTS );
-		$pattern = '#https?://(?:' . implode( '|', $hosts ) . ')/[^\s<]*#i';
+		$pattern = '#(?<![\"\'=])https?://(?:' . implode( '|', $hosts ) . ')/[^\s<\"\']*#i';
 
 		return (string) preg_replace( $pattern, '', $content );
 	}

--- a/includes/Processor/ContentCleaner.php
+++ b/includes/Processor/ContentCleaner.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Content cleaner.
+ *
+ * @package AI_Importer\Processor
+ */
+
+namespace AI_Importer\Processor;
+
+/**
+ * Strips platform-specific cruft from imported content.
+ *
+ * Local (regex/string-based) cleanup — no API calls. Intended to be
+ * applied to NormalizedItem content before it becomes a WordPress post
+ * so that social-media artifacts (short URLs, trailing hashtag chains,
+ * zero-width characters, excessive blank lines) don't leak into the
+ * final article.
+ */
+class ContentCleaner {
+
+	/**
+	 * Short URL hosts commonly injected by social platforms.
+	 *
+	 * @var array<string>
+	 */
+	private const SHORT_URL_HOSTS = array(
+		't.co',
+		'bit.ly',
+		'buff.ly',
+		'ow.ly',
+		'goo.gl',
+		'tinyurl.com',
+		'ift.tt',
+		'dlvr.it',
+	);
+
+	/**
+	 * Characters to strip (zero-width and BOM family).
+	 *
+	 * @var array<string>
+	 */
+	private const INVISIBLE_CHARS = array(
+		"\u{200B}", // Zero-width space.
+		"\u{200C}", // Zero-width non-joiner.
+		"\u{200D}", // Zero-width joiner.
+		"\u{FEFF}", // Byte-order mark.
+		"\u{2060}", // Word joiner.
+	);
+
+	/**
+	 * Clean a content string.
+	 *
+	 * @param string               $content Raw content.
+	 * @param array<string, mixed> $options Options:
+	 *                                      - 'strip_trailing_hashtags' (bool, default true)
+	 *                                      - 'strip_short_urls'        (bool, default true)
+	 *                                      - 'strip_mentions'          (bool, default false)
+	 *                                      - 'collapse_whitespace'     (bool, default true).
+	 * @return string Cleaned content.
+	 */
+	public function clean( string $content, array $options = array() ): string {
+		$opts = array(
+			'strip_trailing_hashtags' => (bool) ( $options['strip_trailing_hashtags'] ?? true ),
+			'strip_short_urls'        => (bool) ( $options['strip_short_urls'] ?? true ),
+			'strip_mentions'          => (bool) ( $options['strip_mentions'] ?? false ),
+			'collapse_whitespace'     => (bool) ( $options['collapse_whitespace'] ?? true ),
+		);
+
+		$content = str_replace( self::INVISIBLE_CHARS, '', $content );
+
+		if ( $opts['strip_short_urls'] ) {
+			$content = $this->strip_short_urls( $content );
+		}
+
+		if ( $opts['strip_mentions'] ) {
+			$content = $this->strip_mentions( $content );
+		}
+
+		if ( $opts['strip_trailing_hashtags'] ) {
+			$content = $this->strip_trailing_hashtags( $content );
+		}
+
+		if ( $opts['collapse_whitespace'] ) {
+			$content = $this->collapse_whitespace( $content );
+		}
+
+		return trim( $content );
+	}
+
+	/**
+	 * Remove standalone short-URL occurrences.
+	 *
+	 * @param string $content Content.
+	 * @return string Content with short URLs removed.
+	 */
+	private function strip_short_urls( string $content ): string {
+		$hosts   = array_map( 'preg_quote', self::SHORT_URL_HOSTS );
+		$pattern = '#https?://(?:' . implode( '|', $hosts ) . ')/[^\s<]*#i';
+
+		return (string) preg_replace( $pattern, '', $content );
+	}
+
+	/**
+	 * Strip the '@' prefix from handles while leaving email addresses alone.
+	 *
+	 * Matches an '@' only when it is preceded by whitespace or start-of-string
+	 * (so emails like "alice@example.com" remain intact).
+	 *
+	 * @param string $content Content.
+	 * @return string Content with mention prefixes stripped.
+	 */
+	private function strip_mentions( string $content ): string {
+		$pattern = '/(^|\s)@([A-Za-z0-9_]{1,30})/';
+
+		return (string) preg_replace( $pattern, '$1$2', $content );
+	}
+
+	/**
+	 * Remove a trailing run of hashtags at the end of the content.
+	 *
+	 * Matches one or more '#tag' tokens at the very end of the string,
+	 * optionally separated from the body by whitespace or newlines.
+	 *
+	 * @param string $content Content.
+	 * @return string Content with the trailing hashtag run removed.
+	 */
+	private function strip_trailing_hashtags( string $content ): string {
+		$pattern = '/(?:\s*#[A-Za-z0-9_]+)+\s*$/u';
+
+		return (string) preg_replace( $pattern, '', $content );
+	}
+
+	/**
+	 * Collapse runs of 3+ newlines into exactly two and trim per-line whitespace.
+	 *
+	 * @param string $content Content.
+	 * @return string Content with normalized whitespace.
+	 */
+	private function collapse_whitespace( string $content ): string {
+		$content = str_replace( array( "\r\n", "\r" ), "\n", $content );
+		$content = (string) preg_replace( "/[ \t]+/", ' ', $content );
+		$content = (string) preg_replace( "/ *\n */", "\n", $content );
+		$content = (string) preg_replace( "/\n{3,}/", "\n\n", $content );
+
+		return $content;
+	}
+}

--- a/tests/Unit/Processor/ContentCleanerTest.php
+++ b/tests/Unit/Processor/ContentCleanerTest.php
@@ -1,0 +1,244 @@
+<?php
+/**
+ * ContentCleaner class tests.
+ *
+ * @package AI_Importer\Tests\Unit\Processor
+ */
+
+namespace AI_Importer\Tests\Unit\Processor;
+
+use AI_Importer\Processor\ContentCleaner;
+use AI_Importer\Tests\Unit\TestCase;
+
+/**
+ * Tests for the ContentCleaner class.
+ */
+class ContentCleanerTest extends TestCase {
+
+	/**
+	 * Test clean returns empty string for empty input.
+	 *
+	 * @return void
+	 */
+	public function test_clean_returns_empty_string_for_empty_input(): void {
+		$cleaner = new ContentCleaner();
+
+		$this->assertSame( '', $cleaner->clean( '' ) );
+		$this->assertSame( '', $cleaner->clean( '   ' ) );
+	}
+
+	/**
+	 * Test clean strips zero-width characters by default.
+	 *
+	 * @return void
+	 */
+	public function test_clean_strips_zero_width_characters(): void {
+		$cleaner = new ContentCleaner();
+
+		// U+200B zero-width space, U+FEFF BOM, U+200C zero-width non-joiner.
+		$input = "Hello\u{200B}world\u{FEFF}!\u{200C}";
+
+		$this->assertSame( 'Helloworld!', $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean collapses runs of blank lines by default.
+	 *
+	 * @return void
+	 */
+	public function test_clean_collapses_blank_line_runs(): void {
+		$cleaner = new ContentCleaner();
+
+		$input    = "First paragraph.\n\n\n\nSecond paragraph.\n\n\n\n\nThird paragraph.";
+		$expected = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph.";
+
+		$this->assertSame( $expected, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean trims leading and trailing whitespace.
+	 *
+	 * @return void
+	 */
+	public function test_clean_trims_outer_whitespace(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = "\n\n  Content here.  \n\n";
+
+		$this->assertSame( 'Content here.', $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean strips trailing hashtag chains by default.
+	 *
+	 * @return void
+	 */
+	public function test_clean_strips_trailing_hashtag_chain(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = "Great launch today! #WordPress #AI #PHP";
+
+		$this->assertSame( 'Great launch today!', $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean strips trailing hashtag block on its own line.
+	 *
+	 * @return void
+	 */
+	public function test_clean_strips_trailing_hashtag_line(): void {
+		$cleaner = new ContentCleaner();
+
+		$input    = "Great launch today!\n\n#WordPress #AI #PHP";
+		$expected = 'Great launch today!';
+
+		$this->assertSame( $expected, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean does not strip hashtags embedded mid-sentence.
+	 *
+	 * @return void
+	 */
+	public function test_clean_preserves_inline_hashtags(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = 'Loving #WordPress right now — so good.';
+
+		$this->assertSame( $input, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean removes bare t.co URLs by default.
+	 *
+	 * @return void
+	 */
+	public function test_clean_removes_short_urls(): void {
+		$cleaner = new ContentCleaner();
+
+		$input    = 'Check it out https://t.co/abc123 it is great';
+		$expected = 'Check it out it is great';
+
+		$this->assertSame( $expected, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean removes common short URL hosts.
+	 *
+	 * @return void
+	 */
+	public function test_clean_removes_multiple_short_url_hosts(): void {
+		$cleaner = new ContentCleaner();
+
+		$input    = 'See https://bit.ly/xyz and https://t.co/abc and https://buff.ly/q9 plus text';
+		$expected = 'See and and plus text';
+
+		$this->assertSame( $expected, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean leaves long URLs alone.
+	 *
+	 * @return void
+	 */
+	public function test_clean_preserves_long_urls(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = 'Docs at https://developer.wordpress.org/rest-api/ here.';
+
+		$this->assertSame( $input, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean can be opted out of hashtag stripping.
+	 *
+	 * @return void
+	 */
+	public function test_clean_can_disable_trailing_hashtag_strip(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = 'Great launch today! #WordPress #AI';
+
+		$this->assertSame(
+			$input,
+			$cleaner->clean( $input, array( 'strip_trailing_hashtags' => false ) )
+		);
+	}
+
+	/**
+	 * Test clean can be opted out of short URL stripping.
+	 *
+	 * @return void
+	 */
+	public function test_clean_can_disable_short_url_strip(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = 'Check it https://t.co/abc123 out.';
+
+		$this->assertSame(
+			$input,
+			$cleaner->clean( $input, array( 'strip_short_urls' => false ) )
+		);
+	}
+
+	/**
+	 * Test clean strips @ prefix from mentions when strip_mentions is enabled.
+	 *
+	 * @return void
+	 */
+	public function test_clean_strips_mention_prefix_when_enabled(): void {
+		$cleaner = new ContentCleaner();
+
+		$input    = 'Thanks @alice and @bob_42 for the help!';
+		$expected = 'Thanks alice and bob_42 for the help!';
+
+		$this->assertSame(
+			$expected,
+			$cleaner->clean( $input, array( 'strip_mentions' => true ) )
+		);
+	}
+
+	/**
+	 * Test clean leaves mentions alone by default.
+	 *
+	 * @return void
+	 */
+	public function test_clean_preserves_mentions_by_default(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = 'Thanks @alice for the help!';
+
+		$this->assertSame( $input, $cleaner->clean( $input ) );
+	}
+
+	/**
+	 * Test clean does not alter plain email addresses when stripping mentions.
+	 *
+	 * @return void
+	 */
+	public function test_clean_does_not_touch_emails_when_stripping_mentions(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = 'Email me at alice@example.com please.';
+
+		$this->assertSame(
+			$input,
+			$cleaner->clean( $input, array( 'strip_mentions' => true ) )
+		);
+	}
+
+	/**
+	 * Test clean handles all cleanup steps together in a realistic input.
+	 *
+	 * @return void
+	 */
+	public function test_clean_end_to_end(): void {
+		$cleaner = new ContentCleaner();
+
+		$input = "  WordPress 7 launches native AI! \u{200B}\n\n\n\nRead more at https://t.co/xyz 🎉\n\n#WordPress #AI #Launch  ";
+
+		$expected = "WordPress 7 launches native AI!\n\nRead more at 🎉";
+
+		$this->assertSame( $expected, $cleaner->clean( $input ) );
+	}
+}

--- a/tests/Unit/Processor/ContentCleanerTest.php
+++ b/tests/Unit/Processor/ContentCleanerTest.php
@@ -150,6 +150,21 @@ class ContentCleanerTest extends TestCase {
 	}
 
 	/**
+	 * Test clean leaves short URLs inside HTML attributes alone.
+	 *
+	 * @return void
+	 */
+	public function test_clean_preserves_short_urls_inside_html_attributes(): void {
+		$cleaner = new ContentCleaner();
+
+		$double = '<p>Read <a href="https://t.co/abc123">this</a> now.</p>';
+		$single = "<p>Read <a href='https://t.co/abc123'>this</a> now.</p>";
+
+		$this->assertSame( $double, $cleaner->clean( $double ) );
+		$this->assertSame( $single, $cleaner->clean( $single ) );
+	}
+
+	/**
 	 * Test clean can be opted out of hashtag stripping.
 	 *
 	 * @return void


### PR DESCRIPTION
## Summary
- Implements **F5.4** of epic #13 — local (non-AI) cleanup of imported content. Per the PRD, content cruft removal is local processing, so this is a pure utility with no API calls.
- Default transformations: strip zero-width characters, remove bare short URLs (t.co, bit.ly, buff.ly, ow.ly, goo.gl, tinyurl.com, ift.tt, dlvr.it), strip trailing hashtag chains, and collapse blank-line runs.
- Opt-in: \`strip_mentions\` — removes the \`@\` prefix from handles while leaving email addresses alone (boundary-aware regex).
- Opt-out flags for every transformation so callers can tune behavior per-source.

## Scope note
This PR only ships the utility. Wiring it into \`ItemEnhancer\` (so it runs on \`NormalizedItem->content\` during import) will be a follow-up alongside AltTextGenerator and HashtagMapper wiring.

## Test plan
- [x] \`./vendor/bin/phpunit --filter ContentCleaner\` — 16 tests, 17 assertions pass
- [x] Full suite: 383 tests pass
- [x] \`composer run lint\` clean on new files

## Completes epic #13
With this PR and PRs #66/67/68/72/73, all four F5 requirements are implemented:
- F5.1 Alt text — \`AltTextGenerator\` (#72)
- F5.2 Thread stitching — \`ThreadStitcher\` (#68)
- F5.3 Hashtag → tags — \`HashtagMapper\` (#73)
- F5.4 Platform cruft — \`ContentCleaner\` (this PR)

Follow-up: wire AltTextGenerator, HashtagMapper, and ContentCleaner into \`ItemEnhancer\`/media sideload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local content sanitization for imported text with configurable options to remove short standalone URLs, strip social mention prefixes, eliminate terminal hashtag chains, and normalize whitespace—while preserving inline hashtags, email addresses, and short URLs when embedded in link attributes.

* **Tests**
  * Added comprehensive unit tests covering default and option-driven behaviors, edge cases, and end-to-end cleaning scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->