### PR TITLE
Refactor Dashboard to use @wordpress/data store

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@
 import { createRoot } from '@wordpress/element';
 
 import App from './App';
+import './store';
 import './style.scss';
 
 // Wait for DOM to be ready.

--- a/src/pages/Dashboard.js
+++ b/src/pages/Dashboard.js
@@ -2,7 +2,7 @@
  * Dashboard page component.
  */
 
-import { useState, useEffect } from '@wordpress/element';
+import { useDispatch, useSelect } from '@wordpress/data';
 import { __ } from '@wordpress/i18n';
 import {
 	Button,
@@ -11,7 +11,8 @@ import {
 	CardHeader,
 	Notice,
 } from '@wordpress/components';
-import { fetchSources, fetchImports } from '../api';
+
+import { STORE_NAME } from '../store';
 
 /**
  * Dashboard page showing overview and recent activity.
@@ -19,39 +20,31 @@ import { fetchSources, fetchImports } from '../api';
  * @return {JSX.Element} The dashboard page.
  */
 export default function Dashboard() {
-	const [ sources, setSources ] = useState( [] );
-	const [ imports, setImports ] = useState( [] );
-	const [ loading, setLoading ] = useState( true );
-	const [ error, setError ] = useState( null );
+	const { connectedSources, imports, loading, error } = useSelect(
+		( select ) => {
+			const store = select( STORE_NAME );
+			return {
+				connectedSources: store.getConnectedSources(),
+				imports: store.getImports(),
+				loading: store.isLoading(),
+				error: store.getError(),
+			};
+		},
+		[]
+	);
 
-	useEffect( () => {
-		const load = async () => {
-			const [ sourcesData, importsData ] = await Promise.all( [
-				fetchSources().catch( () => [] ),
-				fetchImports( 5 ).catch( () => [] ),
-			] );
-			setSources( sourcesData );
-			setImports( importsData );
-			setLoading( false );
-		};
-		load();
-	}, [] );
+	const { clearError } = useDispatch( STORE_NAME );
 
 	if ( loading ) {
 		return <p>{ __( 'Loading…', 'ai-importer' ) }</p>;
 	}
 
-	const connectedSources = sources.filter( ( s ) => s.is_authenticated );
 	const adminUrl = aiImporter?.adminUrl || '';
 
 	return (
 		<div className="ai-importer-dashboard">
 			{ error && (
-				<Notice
-					status="error"
-					isDismissible
-					onDismiss={ () => setError( null ) }
-				>
+				<Notice status="error" isDismissible onDismiss={ clearError }>
 					{ error }
 				</Notice>
 			) }

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -114,7 +114,7 @@ const resolvers = {
 		}
 	},
 	*getConnectedSources() {
-		yield resolvers.getSources();
+		yield* resolvers.getSources();
 	},
 };
 

--- a/src/store/index.js
+++ b/src/store/index.js
@@ -1,0 +1,140 @@
+/**
+ * Dashboard data store.
+ *
+ * Centralizes fetching of sources and recent imports so dashboard-style
+ * pages can subscribe via useSelect/useDispatch instead of duplicating
+ * useState + useEffect with direct API calls.
+ */
+
+import { createReduxStore, register } from '@wordpress/data';
+
+import { fetchSources, fetchImports } from '../api';
+
+export const STORE_NAME = 'ai-importer/dashboard';
+
+const DEFAULT_STATE = {
+	sources: [],
+	imports: [],
+	sourcesLoading: false,
+	importsLoading: false,
+	error: null,
+};
+
+const actions = {
+	setSources( sources ) {
+		return { type: 'SET_SOURCES', sources };
+	},
+	setImports( imports ) {
+		return { type: 'SET_IMPORTS', imports };
+	},
+	setSourcesLoading( loading ) {
+		return { type: 'SET_SOURCES_LOADING', loading };
+	},
+	setImportsLoading( loading ) {
+		return { type: 'SET_IMPORTS_LOADING', loading };
+	},
+	setError( error ) {
+		return { type: 'SET_ERROR', error };
+	},
+	clearError() {
+		return { type: 'SET_ERROR', error: null };
+	},
+};
+
+/**
+ * Reduce dispatched actions into the next state.
+ *
+ * @param {Object} state  Current state.
+ * @param {Object} action Action to apply.
+ * @return {Object} Next state.
+ */
+function reducer( state = DEFAULT_STATE, action ) {
+	switch ( action.type ) {
+		case 'SET_SOURCES':
+			return { ...state, sources: action.sources };
+		case 'SET_IMPORTS':
+			return { ...state, imports: action.imports };
+		case 'SET_SOURCES_LOADING':
+			return { ...state, sourcesLoading: action.loading };
+		case 'SET_IMPORTS_LOADING':
+			return { ...state, importsLoading: action.loading };
+		case 'SET_ERROR':
+			return { ...state, error: action.error };
+		default:
+			return state;
+	}
+}
+
+const selectors = {
+	getSources( state ) {
+		return state.sources;
+	},
+	getConnectedSources( state ) {
+		return state.sources.filter( ( s ) => s.is_authenticated );
+	},
+	getImports( state ) {
+		return state.imports;
+	},
+	isLoading( state ) {
+		return state.sourcesLoading || state.importsLoading;
+	},
+	getError( state ) {
+		return state.error;
+	},
+};
+
+const resolvers = {
+	*getSources() {
+		yield actions.setSourcesLoading( true );
+		try {
+			const sources = yield {
+				type: 'API_FETCH_SOURCES',
+			};
+			yield actions.setSources( sources );
+		} catch ( e ) {
+			yield actions.setError( e.message || 'Failed to load sources.' );
+			yield actions.setSources( [] );
+		} finally {
+			yield actions.setSourcesLoading( false );
+		}
+	},
+	*getImports() {
+		yield actions.setImportsLoading( true );
+		try {
+			const imports = yield {
+				type: 'API_FETCH_IMPORTS',
+				limit: 5,
+			};
+			yield actions.setImports( imports );
+		} catch ( e ) {
+			yield actions.setError( e.message || 'Failed to load imports.' );
+			yield actions.setImports( [] );
+		} finally {
+			yield actions.setImportsLoading( false );
+		}
+	},
+	*getConnectedSources() {
+		yield resolvers.getSources();
+	},
+};
+
+const controls = {
+	API_FETCH_SOURCES() {
+		return fetchSources();
+	},
+	API_FETCH_IMPORTS( { limit } ) {
+		return fetchImports( limit );
+	},
+};
+
+const store = createReduxStore( STORE_NAME, {
+	reducer,
+	actions,
+	selectors,
+	resolvers,
+	controls,
+} );
+
+register( store );
+
+export default store;


### PR DESCRIPTION
## Summary

Closes #50. Replaces the Dashboard page's local `useState`/`useEffect` + direct API calls with a `createReduxStore`-backed store at `ai-importer/dashboard`. The store can now be reused by other dashboard-style pages (Sources, History) instead of duplicating fetch + loading + error state.

## What changed
- New `src/store/index.js` — registers an `@wordpress/data` store with:
  - **Selectors**: `getSources`, `getConnectedSources`, `getImports`, `isLoading`, `getError`
  - **Resolvers**: lazy-fetch sources and imports on first selector read
  - **Actions**: explicit setters plus `clearError` (used by the dismiss button)
  - **Controls**: side-effect-free reducer, fetch happens via `controls`
- `src/pages/Dashboard.js` — uses `useSelect`/`useDispatch`; structurally identical UI
- `src/index.js` — imports the store module so it registers at app boot

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint:js` clean
- [ ] Smoke-test in WordPress admin — page renders, sources/imports load on first navigation, error notice dismisses

## Notes
- Connected-source filtering moved into the selector (`getConnectedSources`) so consumers don't repeat the filter
- This is a foundation; other pages can adopt the same store as a follow-up if desired

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Dashboard now uses a centralized store for sources, imports, loading indicators, and error handling instead of local component state and direct API calls, improving data consistency and simplifying error/loading behavior.
  * App initializes the dashboard store at startup so store-driven data and side effects run when the UI bootstraps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->