### PR TITLE
Add Blogger Atom export adapter (F1.4)

### DIFF
--- a/includes/Adapters/BloggerAdapter.php
+++ b/includes/Adapters/BloggerAdapter.php
@@ -1,0 +1,621 @@
+<?php
+/**
+ * Blogger Atom export adapter.
+ *
+ * Parses a Blogger Atom XML export and extracts posts and pages.
+ *
+ * @package AI_Importer
+ */
+
+namespace AI_Importer\Adapters;
+
+use AI_Importer\Adapters\Manifest\ContentManifest;
+use AI_Importer\Adapters\Manifest\ContentType;
+use AI_Importer\Adapters\Manifest\ManifestItem;
+use AI_Importer\Schema\SettingsSchema;
+use DateTimeImmutable;
+use RuntimeException;
+use SimpleXMLElement;
+use WP_Error;
+
+/**
+ * Adapter for importing content from a Blogger Atom XML export.
+ *
+ * Blogger exports (Settings → Manage Blog → Back up content) are an
+ * Atom feed of "entries" identified by a category whose term encodes
+ * the kind: `http://schemas.google.com/blogger/2008/kind#post`,
+ * `#comment`, `#page`, `#template`, or `#settings`. We only surface
+ * posts and pages; comments are filtered out (they're tracked under
+ * Epic #20 — F12.4 Comment import).
+ *
+ * OAuth is also planned per F1.4 but is intentionally not yet wired —
+ * file upload covers the MVP need and avoids the OAuth review burden.
+ */
+class BloggerAdapter extends AbstractAdapter {
+
+	/**
+	 * Blogger kind URIs.
+	 */
+	private const KIND_POST    = 'http://schemas.google.com/blogger/2008/kind#post';
+	private const KIND_PAGE    = 'http://schemas.google.com/blogger/2008/kind#page';
+	private const KIND_COMMENT = 'http://schemas.google.com/blogger/2008/kind#comment';
+
+	/**
+	 * Blogger atom tag namespace, used to identify user-applied labels.
+	 */
+	private const NS_TAGS = 'http://www.blogger.com/atom/ns#';
+
+	/**
+	 * Parsed entries keyed by ID.
+	 *
+	 * @var array<string, array<string, mixed>>|null
+	 */
+	private ?array $entries = null;
+
+	/**
+	 * Get the unique identifier.
+	 *
+	 * @return string
+	 */
+	public function get_id(): string {
+		return 'blogger';
+	}
+
+	/**
+	 * Get the human-readable name.
+	 *
+	 * @return string
+	 */
+	public function get_name(): string {
+		return 'Blogger';
+	}
+
+	/**
+	 * Get a description.
+	 *
+	 * @return string
+	 */
+	public function get_description(): string {
+		return __( 'Import posts and pages from a Blogger Atom XML export.', 'ai-importer' );
+	}
+
+	/**
+	 * Get the icon.
+	 *
+	 * @return string
+	 */
+	public function get_icon(): string {
+		return 'dashicons-welcome-write-blog';
+	}
+
+	/**
+	 * Get the authentication type.
+	 *
+	 * @return string
+	 */
+	public function get_auth_type(): string {
+		return self::AUTH_TYPE_FILE_UPLOAD;
+	}
+
+	/**
+	 * Authenticate by validating an uploaded Blogger XML export.
+	 *
+	 * @param array<string, mixed> $credentials Must contain 'file' path or 'attachment_id'.
+	 * @return bool True on success.
+	 */
+	public function authenticate( array $credentials ): bool {
+		$file_path = $credentials['file'] ?? '';
+
+		if ( ! empty( $credentials['attachment_id'] ) ) {
+			$file_path = get_attached_file( (int) $credentials['attachment_id'] );
+		}
+
+		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			$this->log_error( 'Blogger export file not found.', $credentials );
+			return false;
+		}
+
+		$validation = $this->validate_export( $file_path );
+
+		if ( is_wp_error( $validation ) ) {
+			$messages = $validation->get_error_messages();
+			$this->log_error( ! empty( $messages ) ? $messages[0] : 'Blogger export validation failed.' );
+			return false;
+		}
+
+		$this->store_credentials(
+			array(
+				'file_path'    => $file_path,
+				'connected_at' => gmdate( 'c' ),
+			)
+		);
+
+		$this->delete_cache( 'manifest' );
+		$this->entries = null;
+
+		return true;
+	}
+
+	/**
+	 * Fetch the content manifest from the export.
+	 *
+	 * @return ContentManifest
+	 * @throws RuntimeException If not authenticated or parsing fails.
+	 */
+	public function fetch_manifest(): ContentManifest {
+		$this->ensure_authenticated();
+
+		$cached = $this->get_cache( 'manifest' );
+
+		if ( $cached instanceof ContentManifest ) {
+			return $cached;
+		}
+
+		$entries  = $this->get_entries();
+		$manifest = new ContentManifest( $this->get_id() );
+
+		foreach ( $entries as $id => $entry ) {
+			$item = new ManifestItem(
+				id: $id,
+				type: $this->classify_entry( $entry ),
+				title: $entry['title'],
+				created_at: $entry['published_at'],
+				excerpt: $this->build_excerpt( $entry['content'] ),
+				media_urls: $entry['media_urls'],
+				metadata: array(
+					'kind' => $entry['kind'],
+					'tags' => $entry['tags'],
+				),
+				original_url: $entry['original_url'],
+				author: $this->build_author( $entry ),
+			);
+
+			$manifest->add_item( $item );
+		}
+
+		$this->set_cache( 'manifest', $manifest, 86400 );
+
+		return $manifest;
+	}
+
+	/**
+	 * Fetch a single entry by ID with full content.
+	 *
+	 * @param string $item_id Entry ID.
+	 * @return array<string, mixed>
+	 * @throws RuntimeException If not authenticated or not found.
+	 */
+	public function fetch_item( string $item_id ): array {
+		$this->ensure_authenticated();
+
+		$entries = $this->get_entries();
+
+		if ( ! isset( $entries[ $item_id ] ) ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new RuntimeException(
+				sprintf(
+					/* translators: %s: entry ID */
+					__( 'Blogger entry with ID "%s" not found in export.', 'ai-importer' ),
+					$item_id
+				)
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		$entry = $entries[ $item_id ];
+
+		return array(
+			'id'           => $item_id,
+			'type'         => $this->classify_entry( $entry )->value,
+			'content'      => $entry['content'],
+			'title'        => $entry['title'],
+			'created_at'   => $entry['published_at']->format( 'c' ),
+			'media_urls'   => $entry['media_urls'],
+			'metadata'     => array(
+				'kind' => $entry['kind'],
+				'tags' => $entry['tags'],
+			),
+			'original_url' => $entry['original_url'],
+			'tags'         => $entry['tags'],
+			'author'       => array(
+				'name' => $entry['author_name'],
+				'url'  => $entry['author_url'],
+			),
+			'raw'          => $entry,
+		);
+	}
+
+	/**
+	 * Get supported content types.
+	 *
+	 * @return array<string>
+	 */
+	public function get_supported_content_types(): array {
+		return array(
+			ContentType::POST->value,
+			ContentType::ARTICLE->value,
+		);
+	}
+
+	/**
+	 * Build the settings schema.
+	 *
+	 * @return SettingsSchema
+	 */
+	protected function build_settings_schema(): SettingsSchema {
+		$schema = new SettingsSchema();
+
+		$schema->add_field(
+			'archive_file',
+			array(
+				'type'        => 'file',
+				'label'       => __( 'Blogger XML Export', 'ai-importer' ),
+				'description' => __( 'Upload your Blogger Atom XML export. Get it from Settings > Manage Blog > Back up content.', 'ai-importer' ),
+				'required'    => true,
+				'accept'      => '.xml',
+			)
+		);
+
+		return $schema;
+	}
+
+	/**
+	 * Validate that a file is a Blogger Atom XML export.
+	 *
+	 * Looks for the Atom feed root and at least one entry whose
+	 * "kind" category points at Blogger's namespace.
+	 *
+	 * @param string $file_path Path to the XML file.
+	 * @return bool|WP_Error True if valid, WP_Error otherwise.
+	 */
+	private function validate_export( string $file_path ): bool|WP_Error {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local uploaded file, wp_remote_get is for HTTP.
+		$contents = file_get_contents( $file_path );
+
+		if ( false === $contents || '' === $contents ) {
+			return new WP_Error(
+				'unreadable_file',
+				__( 'The uploaded file could not be read.', 'ai-importer' )
+			);
+		}
+
+		$xml = $this->load_xml( $contents );
+
+		if ( null === $xml ) {
+			return new WP_Error(
+				'invalid_xml',
+				__( 'The uploaded file is not valid XML.', 'ai-importer' )
+			);
+		}
+
+		// Confirm it's an Atom feed and references the Blogger kind scheme somewhere.
+		if ( false === strpos( $contents, 'http://schemas.google.com/blogger/2008/kind' ) ) {
+			return new WP_Error(
+				'not_blogger',
+				__( 'This XML does not appear to be a Blogger export. Could not find the Blogger kind scheme.', 'ai-importer' )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get all parsed entries, loading them if needed.
+	 *
+	 * @return array<string, array<string, mixed>> Entries keyed by ID.
+	 * @throws RuntimeException If file cannot be read.
+	 */
+	private function get_entries(): array {
+		if ( null !== $this->entries ) {
+			return $this->entries;
+		}
+
+		$credentials = $this->get_stored_credentials();
+		$file_path   = $credentials['file_path'] ?? '';
+
+		if ( empty( $file_path ) || ! file_exists( $file_path ) ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new RuntimeException(
+				__( 'Blogger export file not found. Please re-upload your archive.', 'ai-importer' )
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		$this->entries = $this->parse_export( $file_path );
+
+		return $this->entries;
+	}
+
+	/**
+	 * Parse the Blogger XML export and extract posts/pages.
+	 *
+	 * @param string $file_path Path to the XML file.
+	 * @return array<string, array<string, mixed>> Entries keyed by ID.
+	 * @throws RuntimeException If parsing fails.
+	 */
+	private function parse_export( string $file_path ): array {
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Reading a local uploaded file, wp_remote_get is for HTTP.
+		$contents = file_get_contents( $file_path );
+
+		if ( false === $contents ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new RuntimeException(
+				__( 'Failed to read Blogger export file.', 'ai-importer' )
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		$xml = $this->load_xml( $contents );
+
+		if ( null === $xml ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new RuntimeException(
+				__( 'Failed to parse Blogger XML export.', 'ai-importer' )
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		$entries = array();
+
+		foreach ( $xml->entry as $atom_entry ) {
+			$parsed = $this->parse_entry( $atom_entry );
+
+			if ( null === $parsed ) {
+				continue;
+			}
+
+			$entries[ $parsed['id'] ] = $parsed;
+		}
+
+		if ( empty( $entries ) ) {
+			// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+			throw new RuntimeException(
+				__( 'No posts or pages found in the Blogger export.', 'ai-importer' )
+			);
+			// phpcs:enable WordPress.Security.EscapeOutput.ExceptionNotEscaped
+		}
+
+		return $entries;
+	}
+
+	/**
+	 * Load XML defensively, returning null on parse failure.
+	 *
+	 * @param string $xml_string XML payload.
+	 * @return SimpleXMLElement|null
+	 */
+	private function load_xml( string $xml_string ): ?SimpleXMLElement {
+		$prev = libxml_use_internal_errors( true );
+		$xml  = simplexml_load_string( $xml_string );
+		libxml_clear_errors();
+		libxml_use_internal_errors( $prev );
+
+		return false !== $xml ? $xml : null;
+	}
+
+	/**
+	 * Parse one Atom entry into a normalized post shape.
+	 *
+	 * Returns null when the entry isn't a post or page (e.g. comments,
+	 * settings, templates, or anything we don't currently surface).
+	 *
+	 * @param SimpleXMLElement $entry Atom entry.
+	 * @return array<string, mixed>|null
+	 */
+	private function parse_entry( SimpleXMLElement $entry ): ?array {
+		$kind = $this->extract_kind( $entry );
+
+		if ( null === $kind || self::KIND_COMMENT === $kind ) {
+			return null;
+		}
+
+		// Surface only posts and pages.
+		if ( self::KIND_POST !== $kind && self::KIND_PAGE !== $kind ) {
+			return null;
+		}
+
+		$id = (string) $entry->id;
+		if ( '' === $id ) {
+			return null;
+		}
+
+		$published_raw = (string) $entry->published;
+		$published_at  = $this->parse_date( $published_raw );
+
+		$title       = (string) $entry->title;
+		$content     = (string) $entry->content;
+		$tags        = $this->extract_tags( $entry );
+		$media_urls  = $this->extract_media_urls( $content );
+		$alt_link    = $this->extract_alternate_link( $entry );
+		$author_info = $this->extract_author_info( $entry );
+
+		return array(
+			'id'           => $id,
+			'kind'         => $kind,
+			'title'        => trim( $title ),
+			'content'      => $content,
+			'published_at' => $published_at,
+			'tags'         => $tags,
+			'media_urls'   => $media_urls,
+			'original_url' => $alt_link,
+			'author_name'  => $author_info['name'],
+			'author_url'   => $author_info['url'],
+		);
+	}
+
+	/**
+	 * Look up the entry kind from its category[scheme=#kind] term.
+	 *
+	 * @param SimpleXMLElement $entry Atom entry.
+	 * @return string|null Kind URI or null when missing.
+	 */
+	private function extract_kind( SimpleXMLElement $entry ): ?string {
+		foreach ( $entry->category as $category ) {
+			$scheme = (string) $category['scheme'];
+			$term   = (string) $category['term'];
+
+			if ( 'http://schemas.google.com/g/2005#kind' === $scheme ) {
+				return $term;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract user-applied tags (Blogger labels).
+	 *
+	 * @param SimpleXMLElement $entry Atom entry.
+	 * @return array<string>
+	 */
+	private function extract_tags( SimpleXMLElement $entry ): array {
+		$tags = array();
+
+		foreach ( $entry->category as $category ) {
+			$scheme = (string) $category['scheme'];
+			$term   = (string) $category['term'];
+
+			if ( self::NS_TAGS === $scheme && '' !== $term ) {
+				$tags[] = $term;
+			}
+		}
+
+		return array_values( array_unique( $tags ) );
+	}
+
+	/**
+	 * Extract `<img src>` URLs from the post content HTML.
+	 *
+	 * @param string $content_html Content HTML.
+	 * @return array<string>
+	 */
+	private function extract_media_urls( string $content_html ): array {
+		if ( '' === $content_html ) {
+			return array();
+		}
+
+		$urls = array();
+
+		if ( preg_match_all( '/<img[^>]+src=["\']([^"\']+)["\']/i', $content_html, $matches ) ) {
+			$urls = array_values( array_unique( $matches[1] ) );
+		}
+
+		return $urls;
+	}
+
+	/**
+	 * Extract the alternate link (canonical post URL).
+	 *
+	 * @param SimpleXMLElement $entry Atom entry.
+	 * @return string|null
+	 */
+	private function extract_alternate_link( SimpleXMLElement $entry ): ?string {
+		foreach ( $entry->link as $link ) {
+			if ( 'alternate' === (string) $link['rel'] ) {
+				$href = (string) $link['href'];
+				return '' !== $href ? $href : null;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract author name + uri.
+	 *
+	 * @param SimpleXMLElement $entry Atom entry.
+	 * @return array{name: string|null, url: string|null}
+	 */
+	private function extract_author_info( SimpleXMLElement $entry ): array {
+		$name = null;
+		$url  = null;
+
+		if ( isset( $entry->author ) ) {
+			$author = $entry->author;
+			$name   = '' !== (string) $author->name ? (string) $author->name : null;
+			$url    = '' !== (string) $author->uri ? (string) $author->uri : null;
+		}
+
+		return array(
+			'name' => $name,
+			'url'  => $url,
+		);
+	}
+
+	/**
+	 * Build the manifest author array for an entry.
+	 *
+	 * @param array<string, mixed> $entry Parsed entry.
+	 * @return array<string, string>|null
+	 */
+	private function build_author( array $entry ): ?array {
+		if ( empty( $entry['author_name'] ) && empty( $entry['author_url'] ) ) {
+			return null;
+		}
+
+		$author = array();
+		if ( ! empty( $entry['author_name'] ) ) {
+			$author['name'] = (string) $entry['author_name'];
+		}
+		if ( ! empty( $entry['author_url'] ) ) {
+			$author['url'] = (string) $entry['author_url'];
+		}
+
+		return $author;
+	}
+
+	/**
+	 * Classify a Blogger entry as POST or ARTICLE.
+	 *
+	 * Heuristic: 500+ words → ARTICLE, otherwise POST. Pages classify
+	 * the same way. Threshold matches the Medium adapter for cross-
+	 * source consistency.
+	 *
+	 * @param array<string, mixed> $entry Parsed entry.
+	 * @return ContentType
+	 */
+	private function classify_entry( array $entry ): ContentType {
+		$word_count = str_word_count( wp_strip_all_tags( (string) $entry['content'] ) );
+
+		return $word_count >= 500 ? ContentType::ARTICLE : ContentType::POST;
+	}
+
+	/**
+	 * Build a short excerpt from the content HTML.
+	 *
+	 * @param string $content_html Full content HTML.
+	 * @return string|null Plain-text excerpt or null when content is empty.
+	 */
+	private function build_excerpt( string $content_html ): ?string {
+		$plain = wp_strip_all_tags( $content_html );
+		$plain = trim( preg_replace( '/\s+/', ' ', $plain ) ?? '' );
+
+		if ( '' === $plain ) {
+			return null;
+		}
+
+		if ( mb_strlen( $plain ) <= 160 ) {
+			return $plain;
+		}
+
+		return mb_substr( $plain, 0, 157 ) . '...';
+	}
+
+	/**
+	 * Parse a Blogger ISO-8601 date string.
+	 *
+	 * @param string $date_string Date string.
+	 * @return DateTimeImmutable
+	 */
+	private function parse_date( string $date_string ): DateTimeImmutable {
+		if ( '' === $date_string ) {
+			return new DateTimeImmutable();
+		}
+
+		try {
+			return new DateTimeImmutable( $date_string );
+		} catch ( \Exception $e ) {
+			return new DateTimeImmutable();
+		}
+	}
+}

--- a/includes/Normalizer/BloggerNormalizer.php
+++ b/includes/Normalizer/BloggerNormalizer.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Blogger content normalizer.
+ *
+ * @package AI_Importer
+ */
+
+namespace AI_Importer\Normalizer;
+
+use AI_Importer\Adapters\Manifest\ContentType;
+
+/**
+ * Normalizes raw Blogger Atom data from BloggerAdapter::fetch_item()
+ * into the universal NormalizedItem format.
+ *
+ * Expected raw item shape from BloggerAdapter:
+ *   id, type, content, title, created_at, media_urls, metadata,
+ *   original_url, tags, author, raw
+ */
+class BloggerNormalizer extends ContentNormalizer {
+
+	/**
+	 * Get the adapter ID this normalizer handles.
+	 *
+	 * @return string
+	 */
+	public function get_adapter_id(): string {
+		return 'blogger';
+	}
+
+	/**
+	 * Normalize a raw Blogger item into a NormalizedItem.
+	 *
+	 * @param array<string, mixed> $raw_item Raw item from BloggerAdapter::fetch_item().
+	 * @return NormalizedItem
+	 */
+	public function normalize( array $raw_item ): NormalizedItem {
+		$content = $this->clean_content( (string) ( $raw_item['content'] ?? '' ) );
+
+		$media_urls = $raw_item['media_urls'] ?? array();
+		$media      = $this->extract_media_from_urls( is_array( $media_urls ) ? $media_urls : array() );
+
+		$metadata = is_array( $raw_item['metadata'] ?? null ) ? $raw_item['metadata'] : array();
+		$tags     = is_array( $raw_item['tags'] ?? null ) ? $raw_item['tags'] : array();
+
+		$content_type = $this->resolve_content_type( $raw_item['type'] ?? 'post' );
+
+		$author       = $this->extract_author( $raw_item );
+		$created_at   = (string) ( $raw_item['created_at'] ?? '' );
+		$publish_date = '' !== $created_at
+			? $this->convert_date( $created_at )
+			: new \DateTimeImmutable();
+
+		return new NormalizedItem(
+			source_id: (string) $raw_item['id'],
+			source_adapter: 'blogger',
+			content_type: $content_type,
+			content: $content,
+			publish_date: $publish_date,
+			title: $raw_item['title'] ?? null,
+			source_url: $raw_item['original_url'] ?? null,
+			media: $media,
+			metadata: $metadata,
+			engagement: array(),
+			author_name: $author['name'],
+			author_url: $author['url'],
+			parent_id: null,
+			tags: $tags,
+		);
+	}
+
+	/**
+	 * Resolve a content type string to the ContentType enum.
+	 *
+	 * @param string $type Content type string from the adapter.
+	 * @return ContentType
+	 */
+	private function resolve_content_type( string $type ): ContentType {
+		return ContentType::tryFrom( $type ) ?? ContentType::POST;
+	}
+}

--- a/includes/Normalizer/BloggerNormalizer.php
+++ b/includes/Normalizer/BloggerNormalizer.php
@@ -52,7 +52,7 @@ class BloggerNormalizer extends ContentNormalizer {
 			: new \DateTimeImmutable();
 
 		return new NormalizedItem(
-			source_id: (string) $raw_item['id'],
+			source_id: (string) ( $raw_item['id'] ?? '' ),
 			source_adapter: 'blogger',
 			content_type: $content_type,
 			content: $content,

--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -8,6 +8,7 @@
 namespace AI_Importer;
 
 use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Adapters\BloggerAdapter;
 use AI_Importer\Adapters\InstagramAdapter;
 use AI_Importer\Adapters\MediumAdapter;
 use AI_Importer\Adapters\TwitterAdapter;
@@ -81,6 +82,7 @@ class Plugin {
 		$this->adapter_registry->register( new TwitterAdapter() );
 		$this->adapter_registry->register( new MediumAdapter() );
 		$this->adapter_registry->register( new InstagramAdapter() );
+		$this->adapter_registry->register( new BloggerAdapter() );
 
 		/**
 		 * Fires when adapters should be registered.

--- a/includes/Processor/ImportProcessor.php
+++ b/includes/Processor/ImportProcessor.php
@@ -9,6 +9,7 @@ namespace AI_Importer\Processor;
 
 use AI_Importer\Adapters\AdapterRegistry;
 use AI_Importer\Normalizer\ContentNormalizer;
+use AI_Importer\Normalizer\BloggerNormalizer;
 use AI_Importer\Normalizer\InstagramNormalizer;
 use AI_Importer\Normalizer\MediumNormalizer;
 use AI_Importer\Normalizer\TwitterNormalizer;
@@ -288,6 +289,7 @@ class ImportProcessor {
 				'twitter'   => new TwitterNormalizer(),
 				'medium'    => new MediumNormalizer(),
 				'instagram' => new InstagramNormalizer(),
+				'blogger'   => new BloggerNormalizer(),
 			);
 
 			/**

--- a/tests/Unit/Adapters/BloggerAdapterTest.php
+++ b/tests/Unit/Adapters/BloggerAdapterTest.php
@@ -1,0 +1,334 @@
+<?php
+/**
+ * BloggerAdapter class tests.
+ *
+ * @package AI_Importer\Tests\Unit\Adapters
+ */
+
+namespace AI_Importer\Tests\Unit\Adapters;
+
+use AI_Importer\Adapters\BloggerAdapter;
+use AI_Importer\Adapters\Manifest\ContentType;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests for the BloggerAdapter class.
+ */
+class BloggerAdapterTest extends TestCase {
+
+	/**
+	 * Path to the fixture export.
+	 *
+	 * @var string
+	 */
+	private string $fixture_path;
+
+	/**
+	 * Adapter under test.
+	 *
+	 * @var BloggerAdapter
+	 */
+	private BloggerAdapter $adapter;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		$this->fixture_path = dirname( __DIR__, 2 ) . '/fixtures/blogger-export.xml';
+		$this->adapter      = new BloggerAdapter();
+
+		$stored = array();
+
+		Functions\when( 'get_option' )->alias(
+			static function ( $key, $default_value = false ) use ( &$stored ) {
+				return $stored[ $key ] ?? $default_value;
+			}
+		);
+		Functions\when( 'update_option' )->alias(
+			static function ( $key, $value ) use ( &$stored ) {
+				$stored[ $key ] = $value;
+				return true;
+			}
+		);
+		Functions\when( 'delete_option' )->alias(
+			static function ( $key ) use ( &$stored ) {
+				unset( $stored[ $key ] );
+				return true;
+			}
+		);
+		Functions\when( 'get_transient' )->justReturn( false );
+		Functions\when( 'set_transient' )->justReturn( true );
+		Functions\when( 'delete_transient' )->justReturn( true );
+		Functions\when( 'get_bloginfo' )->justReturn( '6.7' );
+		Functions\when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+	}
+
+	/**
+	 * Authenticate the adapter against the fixture.
+	 *
+	 * @return void
+	 */
+	private function authenticate_adapter(): void {
+		$this->assertTrue(
+			$this->adapter->authenticate( array( 'file' => $this->fixture_path ) )
+		);
+	}
+
+	/**
+	 * Test adapter identity methods.
+	 *
+	 * @return void
+	 */
+	public function test_identity(): void {
+		$this->assertSame( 'blogger', $this->adapter->get_id() );
+		$this->assertSame( 'Blogger', $this->adapter->get_name() );
+		$this->assertSame( 'file_upload', $this->adapter->get_auth_type() );
+	}
+
+	/**
+	 * Test settings schema exposes a file-upload field for XML.
+	 *
+	 * @return void
+	 */
+	public function test_settings_schema(): void {
+		$schema = $this->adapter->get_settings_schema();
+
+		$this->assertTrue( $schema->has_field( 'archive_file' ) );
+		$field = $schema->get_field( 'archive_file' );
+		$this->assertSame( 'file', $field['type'] );
+		$this->assertSame( '.xml', $field['accept'] );
+	}
+
+	/**
+	 * Test authenticate with a valid Blogger XML export.
+	 *
+	 * @return void
+	 */
+	public function test_authenticate_with_valid_export(): void {
+		$this->assertTrue(
+			$this->adapter->authenticate( array( 'file' => $this->fixture_path ) )
+		);
+		$this->assertTrue( $this->adapter->is_authenticated() );
+	}
+
+	/**
+	 * Test authenticate fails with a missing file.
+	 *
+	 * @return void
+	 */
+	public function test_authenticate_with_missing_file(): void {
+		$this->assertFalse(
+			$this->adapter->authenticate( array( 'file' => '/nonexistent/blogger.xml' ) )
+		);
+	}
+
+	/**
+	 * Test authenticate fails for an XML that isn't a Blogger export.
+	 *
+	 * @return void
+	 */
+	public function test_authenticate_with_non_blogger_xml(): void {
+		$tmp = tempnam( sys_get_temp_dir(), 'ai_importer_blogger_' );
+		file_put_contents( $tmp, '<?xml version="1.0"?><rss><channel/></rss>' );
+
+		$this->assertFalse(
+			$this->adapter->authenticate( array( 'file' => $tmp ) )
+		);
+
+		unlink( $tmp );
+	}
+
+	/**
+	 * Test fetch_manifest returns posts and pages but skips comments and settings.
+	 *
+	 * @return void
+	 */
+	public function test_fetch_manifest_filters_to_posts_and_pages(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		// 2 posts + 1 page = 3 items; comment + settings entries are skipped.
+		$this->assertCount( 3, $manifest->get_items() );
+	}
+
+	/**
+	 * Test long content is classified as ARTICLE.
+	 *
+	 * @return void
+	 */
+	public function test_long_post_classified_as_article(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		$found = null;
+		foreach ( $manifest->get_items() as $item ) {
+			if ( 'A long-form post about AI' === $item->title ) {
+				$found = $item;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found );
+		$this->assertSame( ContentType::ARTICLE, $found->type );
+	}
+
+	/**
+	 * Test short content is classified as POST.
+	 *
+	 * @return void
+	 */
+	public function test_short_post_classified_as_post(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		$found = null;
+		foreach ( $manifest->get_items() as $item ) {
+			if ( 'Hello WordPress' === $item->title ) {
+				$found = $item;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found );
+		$this->assertSame( ContentType::POST, $found->type );
+	}
+
+	/**
+	 * Test tags from category[scheme=blogger atom ns] are surfaced.
+	 *
+	 * @return void
+	 */
+	public function test_tags_extracted_from_categories(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		$found = null;
+		foreach ( $manifest->get_items() as $item ) {
+			if ( 'Hello WordPress' === $item->title ) {
+				$found = $item;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found );
+		$this->assertContains( 'WordPress', $found->metadata['tags'] );
+		$this->assertContains( 'PHP', $found->metadata['tags'] );
+	}
+
+	/**
+	 * Test pages are surfaced and tagged with kind metadata.
+	 *
+	 * @return void
+	 */
+	public function test_page_kind_metadata(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		$found = null;
+		foreach ( $manifest->get_items() as $item ) {
+			if ( 'About me' === $item->title ) {
+				$found = $item;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $found );
+		$this->assertSame(
+			'http://schemas.google.com/blogger/2008/kind#page',
+			$found->metadata['kind']
+		);
+	}
+
+	/**
+	 * Test fetch_item returns content with the original URL and tags.
+	 *
+	 * @return void
+	 */
+	public function test_fetch_item_returns_full_data(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		$target_id = null;
+		foreach ( $manifest->get_items() as $id => $item ) {
+			if ( 'Hello WordPress' === $item->title ) {
+				$target_id = $id;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $target_id );
+
+		$item = $this->adapter->fetch_item( $target_id );
+
+		$this->assertSame( 'Hello WordPress', $item['title'] );
+		$this->assertStringContainsString( 'hello-world', $item['content'] );
+		$this->assertSame(
+			'https://example.blogspot.com/2024/01/hello-wordpress.html',
+			$item['original_url']
+		);
+		$this->assertContains( 'WordPress', $item['tags'] );
+		$this->assertSame( 'Test Author', $item['author']['name'] );
+	}
+
+	/**
+	 * Test media URLs are extracted from img tags inside content.
+	 *
+	 * @return void
+	 */
+	public function test_fetch_item_extracts_media_urls(): void {
+		$this->authenticate_adapter();
+
+		$manifest = $this->adapter->fetch_manifest();
+
+		$target_id = null;
+		foreach ( $manifest->get_items() as $id => $item ) {
+			if ( 'Hello WordPress' === $item->title ) {
+				$target_id = $id;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $target_id );
+
+		$item = $this->adapter->fetch_item( $target_id );
+
+		$this->assertContains( 'https://example.com/img/welcome.jpg', $item['media_urls'] );
+	}
+
+	/**
+	 * Test fetch_item throws on unknown ID.
+	 *
+	 * @return void
+	 */
+	public function test_fetch_item_throws_on_missing_id(): void {
+		$this->authenticate_adapter();
+
+		$this->expectException( \RuntimeException::class );
+		$this->adapter->fetch_item( 'no-such-id' );
+	}
+
+	/**
+	 * Test disconnect clears stored credentials.
+	 *
+	 * @return void
+	 */
+	public function test_disconnect_clears_credentials(): void {
+		$this->authenticate_adapter();
+		$this->assertTrue( $this->adapter->is_authenticated() );
+
+		$this->adapter->disconnect();
+
+		$this->assertFalse( $this->adapter->is_authenticated() );
+	}
+}

--- a/tests/Unit/Normalizer/BloggerNormalizerTest.php
+++ b/tests/Unit/Normalizer/BloggerNormalizerTest.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * BloggerNormalizer class tests.
+ *
+ * @package AI_Importer\Tests\Unit\Normalizer
+ */
+
+namespace AI_Importer\Tests\Unit\Normalizer;
+
+use AI_Importer\Adapters\Manifest\ContentType;
+use AI_Importer\Normalizer\BloggerNormalizer;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests for the BloggerNormalizer class.
+ */
+class BloggerNormalizerTest extends TestCase {
+
+	/**
+	 * Normalizer under test.
+	 *
+	 * @var BloggerNormalizer
+	 */
+	private BloggerNormalizer $normalizer;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		$this->normalizer = new BloggerNormalizer();
+
+		Functions\when( 'wp_strip_all_tags' )->alias( 'strip_tags' );
+		Functions\when( 'wp_kses_post' )->alias(
+			static function ( $content ) {
+				return $content;
+			}
+		);
+		Functions\when( 'wp_parse_url' )->alias( 'parse_url' );
+		Functions\when( 'wp_basename' )->alias( 'basename' );
+	}
+
+	/**
+	 * Build a minimal raw item.
+	 *
+	 * @param array<string, mixed> $overrides Override defaults.
+	 * @return array<string, mixed>
+	 */
+	private function make_raw( array $overrides = array() ): array {
+		return array_merge(
+			array(
+				'id'           => 'tag:blogger.com,1999:blog-1.post-1001',
+				'type'         => 'post',
+				'content'      => '<p>Hello</p>',
+				'title'        => 'Hello',
+				'created_at'   => '2024-01-15T10:30:00.000-08:00',
+				'media_urls'   => array(),
+				'metadata'     => array(
+					'kind' => 'http://schemas.google.com/blogger/2008/kind#post',
+					'tags' => array( 'WordPress' ),
+				),
+				'original_url' => 'https://example.blogspot.com/2024/01/hello.html',
+				'tags'         => array( 'WordPress' ),
+				'author'       => array(
+					'name' => 'Test Author',
+					'url'  => 'https://www.blogger.com/profile/1234',
+				),
+			),
+			$overrides
+		);
+	}
+
+	/**
+	 * Test the normalizer reports the correct adapter ID.
+	 *
+	 * @return void
+	 */
+	public function test_supports_blogger(): void {
+		$this->assertSame( 'blogger', $this->normalizer->get_adapter_id() );
+		$this->assertTrue( $this->normalizer->supports( 'blogger' ) );
+	}
+
+	/**
+	 * Test normalize maps the basic fields.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_basic_fields(): void {
+		$item = $this->normalizer->normalize( $this->make_raw() );
+
+		$this->assertSame( 'tag:blogger.com,1999:blog-1.post-1001', $item->source_id );
+		$this->assertSame( 'blogger', $item->source_adapter );
+		$this->assertSame( 'Hello', $item->title );
+		$this->assertSame( 'Test Author', $item->author_name );
+		$this->assertSame(
+			'https://www.blogger.com/profile/1234',
+			$item->author_url
+		);
+	}
+
+	/**
+	 * Test normalize resolves the article content type.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_resolves_article_type(): void {
+		$item = $this->normalizer->normalize(
+			$this->make_raw( array( 'type' => 'article' ) )
+		);
+
+		$this->assertSame( ContentType::ARTICLE, $item->content_type );
+	}
+
+	/**
+	 * Test normalize unknown type falls back to POST.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_unknown_type_falls_back_to_post(): void {
+		$item = $this->normalizer->normalize(
+			$this->make_raw( array( 'type' => 'whatever' ) )
+		);
+
+		$this->assertSame( ContentType::POST, $item->content_type );
+	}
+
+	/**
+	 * Test normalize forwards tags onto the NormalizedItem.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_forwards_tags(): void {
+		$item = $this->normalizer->normalize(
+			$this->make_raw( array( 'tags' => array( 'WordPress', 'PHP' ) ) )
+		);
+
+		$this->assertSame( array( 'WordPress', 'PHP' ), $item->tags );
+	}
+
+	/**
+	 * Test normalize creates media references from URL list.
+	 *
+	 * @return void
+	 */
+	public function test_normalize_extracts_media(): void {
+		$item = $this->normalizer->normalize(
+			$this->make_raw(
+				array( 'media_urls' => array( 'https://example.com/img/a.jpg' ) )
+			)
+		);
+
+		$this->assertCount( 1, $item->media );
+		$this->assertSame(
+			'https://example.com/img/a.jpg',
+			$item->media[0]->source_url
+		);
+	}
+}

--- a/tests/fixtures/blogger-export.xml
+++ b/tests/fixtures/blogger-export.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom"
+      xmlns:openSearch="http://a9.com/-/spec/opensearchrss/1.0/"
+      xmlns:thr="http://purl.org/syndication/thread/1.0">
+  <id>tag:blogger.com,1999:blog-1234567890</id>
+  <updated>2024-06-15T10:30:00.000-08:00</updated>
+  <title type="text">Test Blog</title>
+  <author>
+    <name>Test Author</name>
+    <uri>https://www.blogger.com/profile/1234</uri>
+  </author>
+
+  <entry>
+    <id>tag:blogger.com,1999:blog-1234567890.post-1001</id>
+    <published>2024-01-15T10:30:00.000-08:00</published>
+    <updated>2024-01-15T10:30:00.000-08:00</updated>
+    <category scheme="http://schemas.google.com/g/2005#kind"
+              term="http://schemas.google.com/blogger/2008/kind#post"/>
+    <category scheme="http://www.blogger.com/atom/ns#" term="WordPress"/>
+    <category scheme="http://www.blogger.com/atom/ns#" term="PHP"/>
+    <title type="text">Hello WordPress</title>
+    <content type="html">&lt;p&gt;A short hello-world post.&lt;/p&gt;&lt;p&gt;Welcome aboard!&lt;/p&gt;&lt;img src="https://example.com/img/welcome.jpg"/&gt;</content>
+    <link rel="alternate" type="text/html"
+          href="https://example.blogspot.com/2024/01/hello-wordpress.html"
+          title="Hello WordPress"/>
+    <author>
+      <name>Test Author</name>
+      <uri>https://www.blogger.com/profile/1234</uri>
+      <email>test@example.com</email>
+    </author>
+  </entry>
+
+  <entry>
+    <id>tag:blogger.com,1999:blog-1234567890.post-1002</id>
+    <published>2024-04-01T08:00:00.000-08:00</published>
+    <updated>2024-04-01T08:00:00.000-08:00</updated>
+    <category scheme="http://schemas.google.com/g/2005#kind"
+              term="http://schemas.google.com/blogger/2008/kind#post"/>
+    <category scheme="http://www.blogger.com/atom/ns#" term="AI"/>
+    <title type="text">A long-form post about AI</title>
+    <content type="html">&lt;p&gt;This is the kind of long-form content that makes for a meaty article. We explore many topics including machine learning models, training data, and inference performance characteristics that matter to engineers building real systems for production environments where every detail counts and every millisecond of latency matters to the eventual user experience that you ship.&lt;/p&gt;&lt;p&gt;The first section starts here. We talk about why the topic matters, what the field has tried before, and where the current state of the art sits. We also dig into the trade-offs that practitioners make every day when they pick one approach over another for a real workload.&lt;/p&gt;&lt;p&gt;The second section continues. We dig into transformer architectures, attention heads, key-value caching, and how they all interact when generating tokens at scale on production hardware that needs to balance throughput with latency. Engineers spend months tuning the constants in this section to squeeze the last bit of performance out of expensive accelerators.&lt;/p&gt;&lt;p&gt;The third section keeps building. Pre-training is just the beginning; post-training, supervised fine-tuning, and reinforcement learning from human feedback shape how the model behaves and what it ultimately says. The order of these stages matters more than people often realise, and skipping any of them can cause the model to drift in surprising ways once it is deployed in front of real users.&lt;/p&gt;&lt;p&gt;Section four follows. Memory hierarchy, page size, prefix caching, speculative decoding, and continuous batching are critical to wringing throughput out of expensive GPUs. The compiler stack, the kernel scheduler, and the runtime all need to cooperate, and any one of them being slightly off can cost you a factor of two in cost per token served.&lt;/p&gt;&lt;p&gt;Section five wraps up. Distillation lets us deliver smaller models that retain the capability profile of the bigger ones at a fraction of the cost, which is how mass-market AI becomes economically viable in the first place. The frontier always extends, and the techniques that look like magic today will be table stakes tomorrow as compute keeps getting cheaper and methods keep getting better.&lt;/p&gt;&lt;p&gt;Section six closes out. Routing, caching, batching, and intelligent retries make production systems usable in the real world. The boring infrastructure work is what differentiates a research demo from a product, and engineers who learn to do this well are worth their weight in gold to any team trying to ship something real.&lt;/p&gt;&lt;p&gt;Section seven offers some closing thoughts on where the field is going, what the next year of progress probably looks like, and which open problems are worth your attention. We discuss the gap between what current systems can do and what users actually want, and we talk about the tooling and infrastructure that researchers wish they had today but don&#39;t. The hardest part of progress in this field is often less about the underlying science and more about the practical engineering scaffolding that turns a clever idea into something a non-expert can use without thinking about it.&lt;/p&gt;&lt;p&gt;Finally, an epilogue: the people who do this work are remarkable, and many of them got here through unconventional paths. If you are reading this and wondering whether you could contribute to the next wave of progress, the answer is almost certainly yes; the only question is what your particular contribution looks like, and you will not know until you start trying things that interest you.&lt;/p&gt;</content>
+    <link rel="alternate" type="text/html"
+          href="https://example.blogspot.com/2024/04/long-form-ai.html"/>
+    <author>
+      <name>Test Author</name>
+      <uri>https://www.blogger.com/profile/1234</uri>
+    </author>
+  </entry>
+
+  <entry>
+    <id>tag:blogger.com,1999:blog-1234567890.post-1003</id>
+    <published>2024-05-01T08:00:00.000-08:00</published>
+    <updated>2024-05-01T08:00:00.000-08:00</updated>
+    <category scheme="http://schemas.google.com/g/2005#kind"
+              term="http://schemas.google.com/blogger/2008/kind#page"/>
+    <title type="text">About me</title>
+    <content type="html">&lt;p&gt;Just a short about-me page.&lt;/p&gt;</content>
+    <link rel="alternate" type="text/html"
+          href="https://example.blogspot.com/p/about.html"/>
+    <author>
+      <name>Test Author</name>
+    </author>
+  </entry>
+
+  <entry>
+    <id>tag:blogger.com,1999:blog-1234567890.post-COMMENT-555</id>
+    <published>2024-01-16T11:00:00.000-08:00</published>
+    <updated>2024-01-16T11:00:00.000-08:00</updated>
+    <category scheme="http://schemas.google.com/g/2005#kind"
+              term="http://schemas.google.com/blogger/2008/kind#comment"/>
+    <thr:in-reply-to ref="tag:blogger.com,1999:blog-1234567890.post-1001"
+                     href="https://example.blogspot.com/2024/01/hello-wordpress.html"
+                     type="text/html"/>
+    <title type="text">A comment from a reader</title>
+    <content type="html">Nice post!</content>
+    <author>
+      <name>Reader Person</name>
+    </author>
+  </entry>
+
+  <entry>
+    <id>tag:blogger.com,1999:blog-1234567890.post-SETTINGS-9</id>
+    <category scheme="http://schemas.google.com/g/2005#kind"
+              term="http://schemas.google.com/blogger/2008/kind#settings"/>
+    <title>BLOG_SETTINGS</title>
+    <content type="text">SETTING:VALUE</content>
+  </entry>
+</feed>


### PR DESCRIPTION
## Summary

Adds the **Blogger adapter** for Issue #9 — final MVP source platform.

With this PR, all four MVP source adapters from Issue #9 (Twitter, Medium, Instagram, **Blogger**) are implemented.

Users upload their Blogger Atom XML export (Settings → Manage Blog → Back up content). The adapter parses the feed via SimpleXML and classifies each entry by its kind category:

| Atom category term | Action |
|---|---|
| \`...kind#post\` | imported as POST or ARTICLE |
| \`...kind#page\` | imported as POST or ARTICLE |
| \`...kind#comment\` | filtered (tracked under #20 — F12.4) |
| \`...kind#settings\` / \`...kind#template\` | filtered |

Tags come from \`category[scheme=blogger atom ns#]\` terms; media URLs from \`<img src>\` in the entry content; canonical URL from \`link[rel=alternate]\`; author from \`<author><name>\`/\`<uri>\`.

Long-form entries (500+ words) classify as ARTICLE, matching the Medium adapter's threshold for cross-source consistency.

### OAuth deferred
F1.4 lists OAuth as an alternative auth path. The class doc documents it as "planned but not yet wired" — file upload covers the MVP need without the OAuth review burden. Tracked as a future enhancement.

### Wiring
- \`Plugin::init()\` registers \`new BloggerAdapter()\`
- \`ImportProcessor::get_normalizer()\` returns \`new BloggerNormalizer()\` for \`blogger\`

## Test plan
- [x] \`./vendor/bin/phpunit\` — 455 tests, 982 assertions pass (20 new)
- [x] \`composer run lint\` clean
- [x] \`./vendor/bin/phpstan analyse\` clean
- [x] \`tests/fixtures/blogger-export.xml\` covers: short post with tags + media, long-form article (500+ words), page, comment (filtered), settings entry (filtered)

## Closes
Closes #9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Blogger import adapter with XML file upload authentication
  * Imports only posts and pages, extracting titles, authors, dates, tags, media URLs, and canonical links
  * Builds searchable content manifest and returns full item content on demand
  * Classifies content (article vs post) and generates excerpts

* **Tests**
  * Added comprehensive unit tests and an XML fixture covering import, normalization, classification, media extraction, and error cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->