### PR TITLE
Lean on WP 7.0 core AI and Connectors API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 AI Importer is a universal content migration tool for WordPress. Connect a source (via OAuth, API key, or file upload), review an AI-generated mapping of how your content will land in WordPress, and run a background import that preserves dates, media, and relationships.
 
-The plugin uses the native WordPress AI capabilities introduced in WordPress 7.0 (`wp_get_ai_client()`) — meaning **you bring your own API key** (Anthropic, OpenAI, Google), and your content is never routed through a third-party service.
+The plugin uses the native WordPress AI capabilities introduced in WordPress 7.0 (`wp_get_ai_client()`). AI provider configuration is managed by core's [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) under **Settings → Connections** — AI Importer never asks for or stores API keys itself, and content is never routed through a third-party service.
 
 ### Key capabilities
 
@@ -71,17 +71,19 @@ flowchart TB
         end
 
         AIClient["WordPress Native AI<br/>wp_get_ai_client()"]
+        Connections["Connectors API<br/>(Settings → Connections)"]
         WPCore["WordPress Core<br/>Posts · Taxonomies · Media"]
     end
 
-    Provider["AI Provider API<br/>(Anthropic, OpenAI, Google)"]
+    Provider["Configured AI Provider"]
 
     UI --> Core
     REST --> Core
     CLI --> Core
     Core --> Adapters
     AI --> AIClient
-    AIClient --> Provider
+    AIClient --> Connections
+    Connections --> Provider
     Processor --> WPCore
     Media --> WPCore
 ```
@@ -163,7 +165,7 @@ flowchart LR
 
 - WordPress **7.0 or later** (the plugin uses `wp_get_ai_client()` from core)
 - PHP **8.1 or later**
-- An API key for an AI provider configured in WordPress settings (Anthropic recommended)
+- An AI connection configured in **Settings → Connections** (the WordPress Connectors API handles provider choice, credentials, and routing)
 
 ### Install for development
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 AI Importer is a universal content migration tool for WordPress. Connect a source (via OAuth, API key, or file upload), review an AI-generated mapping of how your content will land in WordPress, and run a background import that preserves dates, media, and relationships.
 
-The plugin uses the native WordPress AI capabilities introduced in WordPress 7.0 (`wp_get_ai_client()`). AI provider configuration is managed by core's [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) under **Settings → Connections** — AI Importer never asks for or stores API keys itself, and content is never routed through a third-party service.
+The plugin uses the native WordPress AI capabilities introduced in WordPress 7.0 (`wp_get_ai_client()`). AI provider configuration is managed by core's [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) under **Settings → Connections** — AI Importer never asks for or stores API keys itself. Where AI requests are sent (and whether they leave your site at all) is determined entirely by the connector your administrator selects in core.
 
 ### Key capabilities
 

--- a/ai-importer-prd.md
+++ b/ai-importer-prd.md
@@ -799,7 +799,7 @@ Provider selection, credentials, and routing are owned by WordPress core via the
 
 Before import, display estimated AI token usage so users can size the run against their connector's quota or pricing:
 
-```
+```text
 Estimated AI Token Usage
 ────────────────────────
 Alt text generation:     892 images × ~150 tokens = ~134k tokens

--- a/ai-importer-prd.md
+++ b/ai-importer-prd.md
@@ -34,7 +34,7 @@
 
 Unlike existing import tools that require manual configuration and produce inconsistent results, AI Importer uses large language models to understand content structure, suggest optimal mappings, and enhance imported content with features like alt text generation, thread stitching, and SEO optimization.
 
-The plugin follows a "bring your own key" model, leveraging the native WordPress AI capabilities introduced in WordPress 7.0 for LLM infrastructure, making it accessible to any WordPress user with an API key from providers like Anthropic or OpenAI.
+The plugin relies entirely on the native WordPress AI capabilities introduced in WordPress 7.0. AI provider configuration — including credentials, model selection, and routing — is owned by WordPress core via the Connectors API. The plugin contains no provider-specific logic and stores no API keys; users configure their preferred connection once in **Settings → Connections** and AI Importer uses it automatically.
 
 ---
 
@@ -99,7 +99,7 @@ WordPress powers 43% of the web. A universal, AI-powered import solution would:
    Use the migration as an opportunity to improve content: add alt text, generate SEO metadata, stitch threads into articles.
 
 5. **Respect User Autonomy**
-   Bring-your-own-key model. No vendor lock-in. Full control over AI provider choice and data handling.
+   AI provider choice and credential storage are owned by WordPress core's Connectors API. No vendor lock-in, no API keys handled by the plugin, full user control over provider and data handling.
 
 6. **WordPress-Native**
    Feel like a natural part of WordPress. Use blocks, respect theme structures, integrate with existing plugins.
@@ -185,7 +185,7 @@ The AI layer provides:
 - Granular selection of what to import
 - Rollback capability
 - Clear progress and error reporting
-- No data sent to third parties (except chosen AI provider)
+- No data sent to third parties (except the AI provider configured in WordPress Connections)
 
 ---
 
@@ -324,7 +324,7 @@ The AI layer provides:
 │                                                                      │
 │  ┌────────────────────────────────────────────────────────────────┐ │
 │  │            WordPress Native AI (wp_get_ai_client)             │ │
-│  │  • API Key Management    • Model Selection    • AI Client     │ │
+│  │  • Connectors API   • Model Selection   • AI Client            │ │
 │  └────────────────────────────────────────────────────────────────┘ │
 │                                    ▲                                 │
 │                                    │                                 │
@@ -368,8 +368,12 @@ The AI layer provides:
                                     │
                                     ▼
                     ┌───────────────────────────────┐
-                    │      AI Provider API          │
-                    │  (Anthropic, OpenAI, etc.)    │
+                    │  WordPress Connectors API     │
+                    │  (Settings → Connections)     │
+                    └──────────────┬────────────────┘
+                                   ▼
+                    ┌───────────────────────────────┐
+                    │   Configured AI Provider      │
                     └───────────────────────────────┘
 ```
 
@@ -789,28 +793,23 @@ taxonomies. I found 23 thread tutorials in your Twitter archive. I recommend:
 
 ### AI Provider Support
 
-Via the WordPress native AI capabilities (WordPress 7.0+), users can choose their provider:
+Provider selection, credentials, and routing are owned by WordPress core via the [Connectors API](https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/) (WordPress 7.0+). The plugin calls `wp_get_ai_client()` and uses whichever provider the site administrator has configured under **Settings → Connections** — it never asks for, stores, or manages API keys itself.
 
-| Provider | Models | Notes |
-|----------|--------|-------|
-| Anthropic | Claude 3.5 Sonnet, Claude 3 Opus | Recommended |
-| OpenAI | GPT-4o, GPT-4 Turbo | Widely available |
-| Google | Gemini Pro | Alternative option |
+### Token Estimation
 
-### Cost Estimation
-
-Before import, display estimated API usage:
+Before import, display estimated AI token usage so users can size the run against their connector's quota or pricing:
 
 ```
-Estimated AI API Usage
-──────────────────────
+Estimated AI Token Usage
+────────────────────────
 Alt text generation:     892 images × ~150 tokens = ~134k tokens
 Thread stitching:        147 threads × ~500 tokens = ~74k tokens
 SEO meta generation:     2,104 items × ~100 tokens = ~210k tokens
                                             ─────────────────────
                                             Total: ~418k tokens
-                                            Est. cost: ~$0.84 (Claude 3.5 Sonnet)
 ```
+
+Dollar costs are intentionally omitted — pricing depends on the connector and model the site administrator has chosen, both of which are managed by core.
 
 ---
 
@@ -830,14 +829,14 @@ SEO meta generation:     2,104 items × ~100 tokens = ~210k tokens
 4. **Transparent AI Usage**
    Clear indication of what data is sent to AI and why
 
-5. **User-Controlled Keys**
-   API keys stored in WordPress, never transmitted to plugin author
+5. **No Plugin-Held Credentials**
+   AI provider credentials are stored and managed by WordPress core's Connectors API. The plugin never sees, stores, or transmits API keys.
 
 ### Security Measures
 
 | Concern | Mitigation |
 |---------|------------|
-| API Key Storage | Encrypted in wp_options using WordPress salts |
+| AI Provider Credentials | Owned by WordPress core's Connectors API; the plugin never handles them |
 | File Uploads | Validated, scanned, stored in protected directory |
 | OAuth Tokens | Short-lived, stored encrypted, refreshed as needed |
 | XSS in Imported Content | All content sanitized via wp_kses on import |
@@ -1060,7 +1059,7 @@ v2.0.0 - Major Update
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
 | Platform export restrictions | Medium | High | Prioritize file uploads over APIs |
-| AI provider pricing changes | Medium | Medium | Support multiple providers |
+| AI provider pricing changes | Medium | Medium | Provider choice is owned by core's Connectors API; users can switch connectors without plugin changes |
 | WordPress.org rejection | Low | High | Follow guidelines strictly, pre-review |
 | Competition | Medium | Low | Focus on AI differentiation |
 
@@ -1069,8 +1068,8 @@ v2.0.0 - Major Update
 | Risk | Likelihood | Impact | Mitigation |
 |------|------------|--------|------------|
 | Data loss during import | Low | Critical | Dry-run mode, rollback, no source deletion |
-| API key exposure | Low | High | Encrypted storage, security audit |
-| Unexpected AI costs | Medium | Medium | Clear cost estimation before import |
+| API key exposure | Low | High | Plugin never handles AI keys — credentials live in core's Connectors API |
+| Unexpected AI usage | Medium | Medium | Token estimate shown before import; cost depends on the connector chosen in core |
 | Content quality issues | Medium | Medium | Review queue, easy editing |
 
 ---
@@ -1095,7 +1094,7 @@ v2.0.0 - Major Update
 | Native WP Importer | Blogger, RSS | None | Free | Basic, manual |
 | Social Import (plugin) | Twitter, FB | None | $49 | Outdated, limited |
 | Jetvantage | Multiple | None | $99/yr | No AI, complex UI |
-| **AI Importer** | Universal | Full AI | Free | Requires API key |
+| **AI Importer** | Universal | Full AI | Free | Requires WordPress 7.0+ with an AI connector configured |
 
 ### Appendix C: User Research Summary
 

--- a/includes/AI/CostEstimator.php
+++ b/includes/AI/CostEstimator.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Cost estimator for AI-powered enhancements.
+ * Token estimator for AI-powered enhancements.
  *
  * @package AI_Importer\AI
  */
@@ -10,11 +10,15 @@ namespace AI_Importer\AI;
 use WP_Error;
 
 /**
- * Estimates token usage and USD cost for a planned batch of AI enhancements.
+ * Estimates token usage for a planned batch of AI enhancements.
  *
  * No AI calls are made — this is pure math based on per-enhancement token
- * estimates and per-provider pricing. Used by the import preview UI to show
- * users what an enhancement selection will cost before they confirm.
+ * estimates. Used by the import preview UI to show users how many tokens
+ * an enhancement selection will consume before they confirm.
+ *
+ * Provider selection and pricing are owned by WordPress core via the
+ * Connectors API (WordPress 7.0+); this class deliberately does not know
+ * about specific providers or rates.
  */
 class CostEstimator {
 
@@ -40,31 +44,10 @@ class CostEstimator {
 	);
 
 	/**
-	 * Default per-million-token blended rates in USD.
-	 *
-	 * These are approximations that weight input and output tokens together.
-	 * Override via the 'ai_importer_cost_rates' filter for live pricing or
-	 * to add/remove providers.
-	 *
-	 * @var array<string, float>
-	 */
-	private const DEFAULT_RATES_PER_MILLION = array(
-		'claude_sonnet' => 5.0,
-		'claude_opus'   => 15.0,
-		'gpt_4o'        => 5.0,
-		'gpt_4_turbo'   => 10.0,
-		'gemini_pro'    => 1.5,
-	);
-
-	/**
-	 * Estimate cost for a plan of enhancements.
+	 * Estimate token usage for a plan of enhancements.
 	 *
 	 * @param array<string, int> $plan Map of enhancement name => count of items to process.
-	 * @return array<string, mixed>|WP_Error {
-	 *     operations: map of enhancement name => ['count' => int, 'tokens' => int],
-	 *     total_tokens: int,
-	 *     cost_by_provider: map of provider name => float USD
-	 * }
+	 * @return array{operations: array<string, array{count: int, tokens: int}>, total_tokens: int}|WP_Error
 	 */
 	public function estimate( array $plan ) {
 		$operations   = array();
@@ -101,40 +84,9 @@ class CostEstimator {
 			$total_tokens              += $tokens;
 		}
 
-		$rates            = $this->get_rates();
-		$cost_by_provider = array();
-		foreach ( $rates as $provider => $rate_per_million ) {
-			if ( ! is_numeric( $rate_per_million ) ) {
-				continue;
-			}
-			$rate = (float) $rate_per_million;
-			if ( $rate < 0 ) {
-				continue;
-			}
-			$cost_by_provider[ $provider ] = round( ( $total_tokens / 1_000_000 ) * $rate, 2 );
-		}
-
 		return array(
-			'operations'       => $operations,
-			'total_tokens'     => $total_tokens,
-			'cost_by_provider' => $cost_by_provider,
+			'operations'   => $operations,
+			'total_tokens' => $total_tokens,
 		);
-	}
-
-	/**
-	 * Resolve the rates table, honoring the ai_importer_cost_rates filter.
-	 *
-	 * @return array<string, float>
-	 */
-	private function get_rates(): array {
-		/**
-		 * Filter the per-million-token blended USD rates used for cost estimation.
-		 *
-		 * Return an associative array of provider name => float dollars per million tokens.
-		 * Replaces defaults entirely, so include every provider you want displayed.
-		 *
-		 * @param array<string, float> $rates Default rate table.
-		 */
-		return (array) apply_filters( 'ai_importer_cost_rates', self::DEFAULT_RATES_PER_MILLION );
 	}
 }

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -1,9 +1,19 @@
 /**
- * Settings page placeholder.
+ * Settings page.
+ *
+ * AI Importer relies on the WordPress 7.0+ Connectors API for all AI
+ * provider configuration. This page intentionally exposes no API-key
+ * fields — it only points users to core's Connections settings.
  */
 
 import { __ } from '@wordpress/i18n';
-import { Card, CardBody, CardHeader } from '@wordpress/components';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	ExternalLink,
+} from '@wordpress/components';
 
 /**
  * Settings page component.
@@ -11,18 +21,34 @@ import { Card, CardBody, CardHeader } from '@wordpress/components';
  * @return {JSX.Element} The component.
  */
 export default function Settings() {
+	const adminUrl = aiImporter?.adminUrl || '';
+	const connectionsUrl = `${ adminUrl }options-general.php?page=connections`;
+
 	return (
 		<div className="ai-importer-settings">
 			<Card>
 				<CardHeader>
-					<h2>{ __( 'Settings', 'ai-importer' ) }</h2>
+					<h2>{ __( 'AI Provider', 'ai-importer' ) }</h2>
 				</CardHeader>
 				<CardBody>
 					<p>
 						{ __(
-							'Settings will be available in a future update.',
+							'AI Importer uses WordPress core AI features (introduced in WordPress 7.0). Configure your AI provider once in Settings → Connections and AI Importer will use it automatically.',
 							'ai-importer'
 						) }
+					</p>
+					<p>
+						<Button variant="primary" href={ connectionsUrl }>
+							{ __( 'Open Connections settings', 'ai-importer' ) }
+						</Button>
+					</p>
+					<p>
+						<ExternalLink href="https://make.wordpress.org/core/2026/03/18/introducing-the-connectors-api-in-wordpress-7-0/">
+							{ __(
+								'Learn about the Connectors API',
+								'ai-importer'
+							) }
+						</ExternalLink>
 					</p>
 				</CardBody>
 			</Card>

--- a/tests/Unit/AI/CostEstimatorTest.php
+++ b/tests/Unit/AI/CostEstimatorTest.php
@@ -9,7 +9,6 @@ namespace AI_Importer\Tests\Unit\AI;
 
 use AI_Importer\AI\CostEstimator;
 use AI_Importer\Tests\Unit\TestCase;
-use Brain\Monkey\Filters;
 use WP_Error;
 
 /**
@@ -29,14 +28,10 @@ class CostEstimatorTest extends TestCase {
 
 		$this->assertSame( 0, $result['total_tokens'] );
 		$this->assertSame( array(), $result['operations'] );
-		$this->assertArrayHasKey( 'cost_by_provider', $result );
-		foreach ( $result['cost_by_provider'] as $cost ) {
-			$this->assertSame( 0.0, $cost );
-		}
 	}
 
 	/**
-	 * Test single enhancement returns matching token and cost estimates.
+	 * Test single enhancement returns matching token estimate.
 	 *
 	 * @return void
 	 */
@@ -49,7 +44,6 @@ class CostEstimatorTest extends TestCase {
 		$this->assertSame( 100, $result['operations']['alt_text']['count'] );
 		$this->assertSame( 15000, $result['operations']['alt_text']['tokens'] ); // 100 * 150.
 		$this->assertSame( 15000, $result['total_tokens'] );
-		$this->assertGreaterThan( 0, $result['cost_by_provider']['claude_sonnet'] );
 	}
 
 	/**
@@ -101,66 +95,17 @@ class CostEstimatorTest extends TestCase {
 	}
 
 	/**
-	 * Test cost breakdown uses per-million-token rates.
+	 * Test result no longer carries provider-specific cost data.
 	 *
-	 * 1M tokens × $5/M for Claude Sonnet = $5.00.
-	 *
-	 * @return void
-	 */
-	public function test_cost_uses_per_million_rates(): void {
-		$estimator = new CostEstimator();
-
-		// 1,000,000 / 150 tokens-per-alt-text ≈ 6667 alt texts -> 1,000,050 tokens; close enough to test scale.
-		// Use title_generation @ 100 tokens each: 10000 * 100 = 1,000,000 tokens.
-		$result = $estimator->estimate( array( 'title_generation' => 10000 ) );
-
-		$this->assertSame( 1_000_000, $result['total_tokens'] );
-		$this->assertEqualsWithDelta( 5.0, $result['cost_by_provider']['claude_sonnet'], 0.001 );
-	}
-
-	/**
-	 * Test ai_importer_cost_rates filter can override provider rates.
+	 * Provider/pricing concerns moved to the WordPress Connectors API.
 	 *
 	 * @return void
 	 */
-	public function test_rates_filter_overrides_defaults(): void {
-		Filters\expectApplied( 'ai_importer_cost_rates' )
-			->once()
-			->andReturn(
-				array(
-					'custom_provider' => 2.0,
-				)
-			);
-
+	public function test_result_has_no_provider_cost_breakdown(): void {
 		$estimator = new CostEstimator();
-		$result    = $estimator->estimate( array( 'title_generation' => 10000 ) );
 
-		$this->assertArrayHasKey( 'custom_provider', $result['cost_by_provider'] );
-		$this->assertArrayNotHasKey( 'claude_sonnet', $result['cost_by_provider'] );
-		$this->assertEqualsWithDelta( 2.0, $result['cost_by_provider']['custom_provider'], 0.001 );
-	}
+		$result = $estimator->estimate( array( 'title_generation' => 100 ) );
 
-	/**
-	 * Test invalid rate values from the filter are skipped instead of crashing.
-	 *
-	 * @return void
-	 */
-	public function test_invalid_filter_rates_are_skipped(): void {
-		Filters\expectApplied( 'ai_importer_cost_rates' )
-			->once()
-			->andReturn(
-				array(
-					'good'     => 5.0,
-					'string'   => 'free', // Non-numeric — should be skipped, not crash.
-					'negative' => -1.0,   // Negative — should be skipped.
-				)
-			);
-
-		$estimator = new CostEstimator();
-		$result    = $estimator->estimate( array( 'title_generation' => 10000 ) );
-
-		$this->assertArrayHasKey( 'good', $result['cost_by_provider'] );
-		$this->assertArrayNotHasKey( 'string', $result['cost_by_provider'] );
-		$this->assertArrayNotHasKey( 'negative', $result['cost_by_provider'] );
+		$this->assertArrayNotHasKey( 'cost_by_provider', $result );
 	}
 }


### PR DESCRIPTION
## Summary
- Drop hardcoded provider names and per-million-token rates from `CostEstimator`; keep token estimation only since provider/pricing now live in core's Connectors API.
- Replace the placeholder Settings page with a thin pointer to **Settings → Connections** so users go to core for AI configuration instead of expecting plugin-level fields.
- Update README and PRD: remove "bring your own API key" framing, the per-provider model table, and dollar-cost examples; reference the Connectors API and update the architecture diagrams.

The plugin already required WordPress 7.0 and used `wp_get_ai_client()`, so no functional changes to the AI service itself — this PR removes the remaining custom provider/credential surface around it.

Refs adamsilverstein/ai-feedback#142

## Test plan
- [x] `composer run lint` — clean
- [x] `composer run test` — 433 tests, all pass
- [x] `npm run lint:js` — clean
- [x] `npm run build` — succeeds
- [ ] Manually verify the Settings page renders and the Connections button targets `options-general.php?page=connections`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings page now guides users to configure AI providers via Settings → Connections and links to connection settings.

* **Documentation**
  * README and product docs updated to reflect WordPress Connectors API–managed AI connections and token-based guidance.

* **Refactor**
  * Cost estimator switched from USD cost outputs to token-only estimates (operations and total tokens).

* **Tests**
  * Tests updated to assert token-focused outputs and remove provider-specific cost expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->