### PR TITLE
Add /sources/{id}/mapping-suggestions REST endpoint (F3.3)

### DIFF
--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -8,6 +8,10 @@
 namespace AI_Importer\REST;
 
 use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\AI\AIService;
+use AI_Importer\AI\ContentAnalyzer;
+use AI_Importer\AI\MappingSuggester;
+use AI_Importer\Schema\SiteSchemaAnalyzer;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -18,11 +22,12 @@ use WP_REST_Server;
  * Handles REST API endpoints for managing source adapters.
  *
  * Endpoints:
- *   GET    /sources                     - List all adapters
- *   GET    /sources/{id}                - Get adapter details with schema
- *   POST   /sources/{id}/connect        - Authenticate an adapter
- *   POST   /sources/{id}/disconnect     - Disconnect an adapter
- *   GET    /sources/{id}/manifest       - Fetch content manifest
+ *   GET    /sources                              - List all adapters
+ *   GET    /sources/{id}                         - Get adapter details with schema
+ *   POST   /sources/{id}/connect                 - Authenticate an adapter
+ *   POST   /sources/{id}/disconnect              - Disconnect an adapter
+ *   GET    /sources/{id}/manifest                - Fetch content manifest
+ *   GET    /sources/{id}/mapping-suggestions     - Generate AI mapping suggestions
  */
 class SourcesController extends WP_REST_Controller {
 
@@ -39,6 +44,47 @@ class SourcesController extends WP_REST_Controller {
 	 * @var string
 	 */
 	protected $rest_base = 'sources';
+
+	/**
+	 * Content analyzer used for mapping suggestions.
+	 *
+	 * @var ContentAnalyzer|null
+	 */
+	private ?ContentAnalyzer $content_analyzer;
+
+	/**
+	 * Site schema analyzer used for mapping suggestions.
+	 *
+	 * @var SiteSchemaAnalyzer|null
+	 */
+	private ?SiteSchemaAnalyzer $site_schema_analyzer;
+
+	/**
+	 * Mapping suggester used for mapping suggestions.
+	 *
+	 * @var MappingSuggester|null
+	 */
+	private ?MappingSuggester $mapping_suggester;
+
+	/**
+	 * Constructor.
+	 *
+	 * Collaborators are injectable so tests can substitute mocks; in
+	 * production we lazily instantiate defaults that share an AIService.
+	 *
+	 * @param ContentAnalyzer|null    $content_analyzer     Content analyzer.
+	 * @param SiteSchemaAnalyzer|null $site_schema_analyzer Site schema analyzer.
+	 * @param MappingSuggester|null   $mapping_suggester    Mapping suggester.
+	 */
+	public function __construct(
+		?ContentAnalyzer $content_analyzer = null,
+		?SiteSchemaAnalyzer $site_schema_analyzer = null,
+		?MappingSuggester $mapping_suggester = null
+	) {
+		$this->content_analyzer     = $content_analyzer;
+		$this->site_schema_analyzer = $site_schema_analyzer;
+		$this->mapping_suggester    = $mapping_suggester;
+	}
 
 	/**
 	 * Register REST routes.
@@ -128,6 +174,30 @@ class SourcesController extends WP_REST_Controller {
 							'required'          => true,
 							'type'              => 'string',
 							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/mapping-suggestions',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_mapping_suggestions' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'id'          => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'sample_size' => array(
+							'required'          => false,
+							'type'              => 'integer',
+							'sanitize_callback' => 'absint',
 						),
 					),
 				),
@@ -327,6 +397,130 @@ class SourcesController extends WP_REST_Controller {
 		}
 
 		return rest_ensure_response( $manifest->to_array() );
+	}
+
+	/**
+	 * Generate AI mapping suggestions for a connected source.
+	 *
+	 * Fetches the manifest, runs ContentAnalyzer over the items and
+	 * SiteSchemaAnalyzer over the destination site, then asks
+	 * MappingSuggester to recommend post-type, taxonomy, and content
+	 * mappings with reasoning.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_mapping_suggestions( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		if ( ! $adapter->is_authenticated() ) {
+			return new WP_Error(
+				'not_authenticated',
+				__( 'This source is not connected. Please connect it first.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		try {
+			$manifest = $adapter->fetch_manifest();
+		} catch ( \RuntimeException $e ) {
+			return new WP_Error(
+				'manifest_error',
+				$e->getMessage(),
+				array( 'status' => 500 )
+			);
+		}
+
+		$options = array();
+		// Forward the optional sample_size hint to the analyzer.
+		$sample_size = $request->get_param( 'sample_size' );
+		if ( null !== $sample_size && $sample_size > 0 ) {
+			$options['sample_size'] = (int) $sample_size;
+		}
+
+		$analysis = $this->get_content_analyzer()->analyze( array_values( $manifest->get_items() ), $options );
+
+		if ( is_wp_error( $analysis ) ) {
+			return $this->wrap_error_with_status( $analysis, 502 );
+		}
+
+		$site_schema = $this->get_site_schema_analyzer()->get_schema();
+		$suggestions = $this->get_mapping_suggester()->suggest( $analysis, $site_schema );
+
+		if ( is_wp_error( $suggestions ) ) {
+			return $this->wrap_error_with_status( $suggestions, 502 );
+		}
+
+		return rest_ensure_response(
+			array(
+				'source_id'   => $adapter->get_id(),
+				'analysis'    => $analysis,
+				'site_schema' => $site_schema,
+				'suggestions' => $suggestions,
+			)
+		);
+	}
+
+	/**
+	 * Lazily build the content analyzer, sharing an AIService.
+	 *
+	 * @return ContentAnalyzer
+	 */
+	private function get_content_analyzer(): ContentAnalyzer {
+		if ( null === $this->content_analyzer ) {
+			$this->content_analyzer = new ContentAnalyzer( new AIService() );
+		}
+
+		return $this->content_analyzer;
+	}
+
+	/**
+	 * Lazily build the site schema analyzer.
+	 *
+	 * @return SiteSchemaAnalyzer
+	 */
+	private function get_site_schema_analyzer(): SiteSchemaAnalyzer {
+		if ( null === $this->site_schema_analyzer ) {
+			$this->site_schema_analyzer = new SiteSchemaAnalyzer();
+		}
+
+		return $this->site_schema_analyzer;
+	}
+
+	/**
+	 * Lazily build the mapping suggester, sharing an AIService.
+	 *
+	 * @return MappingSuggester
+	 */
+	private function get_mapping_suggester(): MappingSuggester {
+		if ( null === $this->mapping_suggester ) {
+			$this->mapping_suggester = new MappingSuggester( new AIService() );
+		}
+
+		return $this->mapping_suggester;
+	}
+
+	/**
+	 * Ensure a WP_Error carries an HTTP status, defaulting to $status.
+	 *
+	 * @param WP_Error $error  Source error.
+	 * @param int      $status Default HTTP status if none is set.
+	 * @return WP_Error
+	 */
+	private function wrap_error_with_status( WP_Error $error, int $status ): WP_Error {
+		$data = $error->get_error_data();
+
+		if ( ! is_array( $data ) || empty( $data['status'] ) ) {
+			$data           = is_array( $data ) ? $data : array();
+			$data['status'] = $status;
+			$error->add_data( $data );
+		}
+
+		return $error;
 	}
 
 	/**

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -197,6 +197,8 @@ class SourcesController extends WP_REST_Controller {
 						'sample_size' => array(
 							'required'          => false,
 							'type'              => 'integer',
+							'minimum'           => 1,
+							'maximum'           => 50,
 							'sanitize_callback' => 'absint',
 						),
 					),

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -468,7 +468,7 @@ class SourcesController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Lazily build the content analyzer, sharing an AIService.
+	 * Lazily build the content analyzer with its own AIService instance.
 	 *
 	 * @return ContentAnalyzer
 	 */
@@ -494,7 +494,7 @@ class SourcesController extends WP_REST_Controller {
 	}
 
 	/**
-	 * Lazily build the mapping suggester, sharing an AIService.
+	 * Lazily build the mapping suggester with its own AIService instance.
 	 *
 	 * @return MappingSuggester
 	 */

--- a/tests/Unit/REST/SourcesControllerTest.php
+++ b/tests/Unit/REST/SourcesControllerTest.php
@@ -12,12 +12,16 @@ use AI_Importer\Adapters\AdapterRegistry;
 use AI_Importer\Adapters\Manifest\ContentManifest;
 use AI_Importer\Adapters\Manifest\ContentType;
 use AI_Importer\Adapters\Manifest\ManifestItem;
+use AI_Importer\AI\ContentAnalyzer;
+use AI_Importer\AI\MappingSuggester;
 use AI_Importer\REST\SourcesController;
 use AI_Importer\Schema\SettingsSchema;
+use AI_Importer\Schema\SiteSchemaAnalyzer;
 use AI_Importer\Tests\Unit\TestCase;
 use Brain\Monkey\Functions;
 use DateTimeImmutable;
 use Mockery;
+use WP_Error;
 use WP_REST_Request;
 
 /**
@@ -163,6 +167,286 @@ class SourcesControllerTest extends TestCase {
 		$result        = $this->controller->get_manifest( $request );
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Test get_mapping_suggestions returns analysis, schema, and suggestions on success.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_returns_payload(): void {
+		$manifest = $this->build_manifest_with_items( 'twitter', 3 );
+		$adapter  = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$analysis    = $this->sample_analysis();
+		$site_schema = $this->sample_site_schema();
+		$suggestions = $this->sample_suggestions();
+
+		$content_analyzer = Mockery::mock( ContentAnalyzer::class );
+		$content_analyzer->shouldReceive( 'analyze' )
+			->once()
+			->with(
+				Mockery::on(
+					static function ( $items ) {
+						// Items must be passed as a positional array (array_values).
+						return is_array( $items ) && array_keys( $items ) === range( 0, count( $items ) - 1 );
+					}
+				),
+				Mockery::type( 'array' )
+			)
+			->andReturn( $analysis );
+
+		$schema_analyzer = Mockery::mock( SiteSchemaAnalyzer::class );
+		$schema_analyzer->shouldReceive( 'get_schema' )->once()->andReturn( $site_schema );
+
+		$suggester = Mockery::mock( MappingSuggester::class );
+		$suggester->shouldReceive( 'suggest' )
+			->once()
+			->with( $analysis, $site_schema )
+			->andReturn( $suggestions );
+
+		$controller    = new SourcesController( $content_analyzer, $schema_analyzer, $suggester );
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$response = $controller->get_mapping_suggestions( $request );
+		$result   = $response->get_data();
+
+		$this->assertSame( 'twitter', $result['source_id'] );
+		$this->assertSame( $analysis, $result['analysis'] );
+		$this->assertSame( $site_schema, $result['site_schema'] );
+		$this->assertSame( $suggestions, $result['suggestions'] );
+	}
+
+	/**
+	 * Test get_mapping_suggestions forwards an explicit sample_size to the analyzer.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_forwards_sample_size(): void {
+		$manifest = $this->build_manifest_with_items( 'twitter', 5 );
+		$adapter  = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$content_analyzer = Mockery::mock( ContentAnalyzer::class );
+		$content_analyzer->shouldReceive( 'analyze' )
+			->once()
+			->with( Mockery::type( 'array' ), array( 'sample_size' => 25 ) )
+			->andReturn( $this->sample_analysis() );
+
+		$schema_analyzer = Mockery::mock( SiteSchemaAnalyzer::class );
+		$schema_analyzer->shouldReceive( 'get_schema' )->andReturn( $this->sample_site_schema() );
+
+		$suggester = Mockery::mock( MappingSuggester::class );
+		$suggester->shouldReceive( 'suggest' )->andReturn( $this->sample_suggestions() );
+
+		$controller             = new SourcesController( $content_analyzer, $schema_analyzer, $suggester );
+		$request                = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id']          = 'twitter';
+		$request['sample_size'] = 25;
+
+		$response = $controller->get_mapping_suggestions( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test get_mapping_suggestions returns 400 when the source is not connected.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_not_authenticated(): void {
+		$this->register_mock_adapter( 'twitter', false );
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$result = $this->controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'not_authenticated', $result->get_error_codes() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test get_mapping_suggestions returns 404 for an unknown source.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_source_not_found(): void {
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/unknown/mapping-suggestions' );
+		$request['id'] = 'unknown';
+
+		$result = $this->controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'source_not_found', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test get_mapping_suggestions surfaces analyzer failures with a 502 status.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_propagates_analyzer_error(): void {
+		$manifest = $this->build_manifest_with_items( 'twitter', 1 );
+		$adapter  = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$content_analyzer = Mockery::mock( ContentAnalyzer::class );
+		$content_analyzer->shouldReceive( 'analyze' )->once()->andReturn(
+			new WP_Error( 'ai_unavailable', 'No provider configured.' )
+		);
+
+		$schema_analyzer = Mockery::mock( SiteSchemaAnalyzer::class );
+		$suggester       = Mockery::mock( MappingSuggester::class );
+
+		$controller    = new SourcesController( $content_analyzer, $schema_analyzer, $suggester );
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$result = $controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_unavailable', $result->get_error_codes() );
+		$this->assertSame( 502, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test get_mapping_suggestions surfaces suggester failures with a 502 status.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_propagates_suggester_error(): void {
+		$manifest = $this->build_manifest_with_items( 'twitter', 1 );
+		$adapter  = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$content_analyzer = Mockery::mock( ContentAnalyzer::class );
+		$content_analyzer->shouldReceive( 'analyze' )->once()->andReturn( $this->sample_analysis() );
+
+		$schema_analyzer = Mockery::mock( SiteSchemaAnalyzer::class );
+		$schema_analyzer->shouldReceive( 'get_schema' )->andReturn( $this->sample_site_schema() );
+
+		$suggester = Mockery::mock( MappingSuggester::class );
+		$suggester->shouldReceive( 'suggest' )->once()->andReturn(
+			new WP_Error( 'ai_mapping_malformed', 'Bad response.' )
+		);
+
+		$controller    = new SourcesController( $content_analyzer, $schema_analyzer, $suggester );
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$result = $controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_mapping_malformed', $result->get_error_codes() );
+		$this->assertSame( 502, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test get_mapping_suggestions surfaces manifest fetch failures.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_manifest_failure(): void {
+		$adapter = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andThrow(
+			new \RuntimeException( 'Archive unreadable.' )
+		);
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$result = $this->controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'manifest_error', $result->get_error_codes() );
+		$this->assertSame( 500, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Build a manifest containing $count items.
+	 *
+	 * @param string $source_id Adapter source ID.
+	 * @param int    $count     Number of items to create.
+	 * @return ContentManifest
+	 */
+	private function build_manifest_with_items( string $source_id, int $count ): ContentManifest {
+		$manifest = new ContentManifest( $source_id );
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$manifest->add_item(
+				new ManifestItem(
+					id: (string) $i,
+					type: ContentType::POST,
+					title: "Item {$i}",
+					created_at: new DateTimeImmutable( '2024-01-15' ),
+				)
+			);
+		}
+
+		return $manifest;
+	}
+
+	/**
+	 * Sample ContentAnalyzer analysis output.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function sample_analysis(): array {
+		return array(
+			'content_types'        => array( 'quick_thoughts' => 3 ),
+			'top_topics'           => array( 'wordpress' ),
+			'writing_style'        => 'casual',
+			'suggested_categories' => array( 'Notes' ),
+			'high_value_content'   => array(),
+		);
+	}
+
+	/**
+	 * Sample SiteSchemaAnalyzer output.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function sample_site_schema(): array {
+		return array(
+			'post_types' => array(
+				array(
+					'slug'   => 'post',
+					'name'   => 'Posts',
+					'public' => true,
+				),
+			),
+			'taxonomies' => array(
+				array(
+					'slug'       => 'category',
+					'name'       => 'Categories',
+					'post_types' => array( 'post' ),
+				),
+			),
+		);
+	}
+
+	/**
+	 * Sample MappingSuggester output.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function sample_suggestions(): array {
+		return array(
+			'post_type_mappings'      => array(
+				array(
+					'source_content_type'   => 'quick_thoughts',
+					'destination_post_type' => 'post',
+					'reasoning'             => 'Short content fits Posts.',
+				),
+			),
+			'taxonomy_mappings'       => array(),
+			'content_transformations' => array(),
+			'summary'                 => 'Map quick thoughts to standard posts.',
+		);
 	}
 
 	/**

--- a/tests/Unit/REST/SourcesControllerTest.php
+++ b/tests/Unit/REST/SourcesControllerTest.php
@@ -346,6 +346,87 @@ class SourcesControllerTest extends TestCase {
 	}
 
 	/**
+	 * Test malformed analyzer errors carrying response data still receive a 502 status.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_sets_status_on_malformed_analyzer_error_with_data(): void {
+		$manifest = $this->build_manifest_with_items( 'twitter', 1 );
+		$adapter  = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$raw_response = array( 'unexpected' => 'shape' );
+
+		$content_analyzer = Mockery::mock( ContentAnalyzer::class );
+		$content_analyzer->shouldReceive( 'analyze' )->once()->andReturn(
+			new WP_Error(
+				'ai_analyze_malformed',
+				'AI analysis response is missing required field: content_type.',
+				array( 'response' => $raw_response )
+			)
+		);
+
+		$schema_analyzer = Mockery::mock( SiteSchemaAnalyzer::class );
+		$suggester       = Mockery::mock( MappingSuggester::class );
+
+		$controller    = new SourcesController( $content_analyzer, $schema_analyzer, $suggester );
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$result = $controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_analyze_malformed', $result->get_error_codes() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 502, $data['status'] );
+		$this->assertSame( $raw_response, $data['response'] );
+	}
+
+	/**
+	 * Test malformed suggester errors carrying response data still receive a 502 status.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_suggestions_sets_status_on_malformed_suggester_error_with_data(): void {
+		$manifest = $this->build_manifest_with_items( 'twitter', 1 );
+		$adapter  = $this->register_mock_adapter( 'twitter', true );
+		$adapter->shouldReceive( 'fetch_manifest' )->once()->andReturn( $manifest );
+
+		$content_analyzer = Mockery::mock( ContentAnalyzer::class );
+		$content_analyzer->shouldReceive( 'analyze' )->once()->andReturn( $this->sample_analysis() );
+
+		$schema_analyzer = Mockery::mock( SiteSchemaAnalyzer::class );
+		$schema_analyzer->shouldReceive( 'get_schema' )->andReturn( $this->sample_site_schema() );
+
+		$raw_response = array( 'mappings' => 'not-an-array' );
+
+		$suggester = Mockery::mock( MappingSuggester::class );
+		$suggester->shouldReceive( 'suggest' )->once()->andReturn(
+			new WP_Error(
+				'ai_mapping_malformed',
+				'AI mapping response field "mappings" must be of type array.',
+				array( 'response' => $raw_response )
+			)
+		);
+
+		$controller    = new SourcesController( $content_analyzer, $schema_analyzer, $suggester );
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mapping-suggestions' );
+		$request['id'] = 'twitter';
+
+		$result = $controller->get_mapping_suggestions( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'ai_mapping_malformed', $result->get_error_codes() );
+
+		$data = $result->get_error_data();
+		$this->assertIsArray( $data );
+		$this->assertSame( 502, $data['status'] );
+		$this->assertSame( $raw_response, $data['response'] );
+	}
+
+	/**
 	 * Test get_mapping_suggestions surfaces manifest fetch failures.
 	 *
 	 * @return void

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -115,6 +115,21 @@ if ( ! class_exists( 'WP_Error' ) ) {
 			}
 			return $this->error_data[ $code ] ?? null;
 		}
+
+		/**
+		 * Add or replace data for an error code (matches WP 5.1+ behaviour).
+		 *
+		 * @param mixed  $data Error data.
+		 * @param string $code Error code; defaults to the first code.
+		 */
+		public function add_data( $data, $code = '' ) {
+			if ( empty( $code ) ) {
+				$code = $this->get_error_codes()[0] ?? '';
+			}
+			if ( '' !== $code ) {
+				$this->error_data[ $code ] = $data;
+			}
+		}
 	}
 }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -117,7 +117,10 @@ if ( ! class_exists( 'WP_Error' ) ) {
 		}
 
 		/**
-		 * Add or replace data for an error code (matches WP 5.1+ behaviour).
+		 * Set data for an error code (simplified shim).
+		 *
+		 * Unlike WP 5.1+, which appends previous data to an additional_data
+		 * stack, this shim simply overwrites any existing data for the code.
 		 *
 		 * @param mixed  $data Error data.
 		 * @param string $code Error code; defaults to the first code.


### PR DESCRIPTION
## Summary

Wires `ContentAnalyzer` + `SiteSchemaAnalyzer` + `MappingSuggester` behind a single `GET /ai-importer/v1/sources/{id}/mapping-suggestions` endpoint so the Import Wizard's mapping step can show AI-recommended post-type, taxonomy, and content-transformation mappings with reasoning.

This is the first user-visible slice of [#11](https://github.com/adamsilverstein/ai-importer/issues/11) (F3 — AI Analysis & Mapping). The components already existed in `includes/AI/` and `includes/Schema/` but were not exposed to the front end.

## What it does

1. Resolves the adapter from the registry (`source_not_found` → 404)
2. Requires the adapter to be authenticated (`not_authenticated` → 400)
3. Fetches the manifest (re-uses the same `try/catch` shape as `get_manifest`, so unreadable archives → 500)
4. Runs `ContentAnalyzer::analyze()` over the manifest items (positional array). An optional `sample_size` query param is forwarded as the analyzer option
5. Runs `SiteSchemaAnalyzer::get_schema()` over the destination site
6. Calls `MappingSuggester::suggest()` and returns `{ source_id, analysis, site_schema, suggestions }`

Upstream AI failures (no provider configured, malformed model output) are surfaced as 502 so the front end can distinguish them from local validation errors.

## Design notes

- `SourcesController` now accepts the analyzer/schema-analyzer/suggester as **constructor parameters** with sensible defaults — production code stays the same, but tests inject Mockery doubles instead of touching `wp_get_ai_client()`.
- The default branch already shares one `AIService` instance across analyzer + suggester to avoid double-instantiating the WordPress AI client.
- Endpoint stays on `SourcesController` (rather than a new controller) because it's per-source and parallels `get_manifest` exactly.

## Tests

Added 6 new test cases on `SourcesControllerTest`:
- `test_get_mapping_suggestions_returns_payload` — happy path, asserts items reach the analyzer as a positional array
- `test_get_mapping_suggestions_forwards_sample_size` — ensures the query param maps to the analyzer option
- `test_get_mapping_suggestions_not_authenticated` — 400
- `test_get_mapping_suggestions_source_not_found` — 404
- `test_get_mapping_suggestions_propagates_analyzer_error` — 502 + original error code preserved
- `test_get_mapping_suggestions_propagates_suggester_error` — 502 + original error code preserved
- `test_get_mapping_suggestions_manifest_failure` — 500 when the adapter throws

The bundled `WP_Error` test stub was missing `add_data()` (added to WP core in 5.1); extended it to match.

## Test plan
- [x] `composer run lint` — clean (41 PHP files)
- [x] `composer run test` — 460/460 pass, 987 assertions (1 pre-existing deprecation, unrelated)
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- [x] `npm run lint:js` — clean
- [x] `npm run build` — webpack compiled successfully

## Follow-up (separate PR)

- Front-end mapping screen consuming this endpoint (covers F3.4 — accept/modify/reject)
- `POST /sources/{id}/mappings` to persist accepted suggestions to `ai_importer_mappings_{adapter}` (F3.5)

Refs #11.