### PR TITLE
Override serialize-javascript to ^7.0.5 (Dependabot alerts)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19745,16 +19745,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/randombytes": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "^5.1.0"
-			}
-		},
 		"node_modules/range-parser": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -20798,13 +20788,13 @@
 			}
 		},
 		"node_modules/serialize-javascript": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-			"integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.5.tgz",
+			"integrity": "sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
-			"dependencies": {
-				"randombytes": "^2.1.0"
+			"engines": {
+				"node": ">=20.0.0"
 			}
 		},
 		"node_modules/serve-index": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
 				"lint-staged": "^16.2.7"
 			},
 			"engines": {
-				"node": ">=18.0.0",
-				"npm": ">=9.0.0"
+				"node": ">=20.0.0",
+				"npm": ">=10.0.0"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"@wordpress/icons": "^10.0.0"
 	},
 	"overrides": {
-		"serialize-javascript": "^7.0.5"
+		"serialize-javascript": "7.0.5"
 	},
 	"lint-staged": {
 		"*.php": [

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
 	"license": "GPL-2.0-or-later",
 	"main": "build/index.js",
 	"engines": {
-		"node": ">=18.0.0",
-		"npm": ">=9.0.0"
+		"node": ">=20.0.0",
+		"npm": ">=10.0.0"
 	},
 	"scripts": {
 		"build": "wp-scripts build",
@@ -46,6 +46,9 @@
 		"@wordpress/element": "^6.0.0",
 		"@wordpress/i18n": "^5.0.0",
 		"@wordpress/icons": "^10.0.0"
+	},
+	"overrides": {
+		"serialize-javascript": "^7.0.5"
 	},
 	"lint-staged": {
 		"*.php": [


### PR DESCRIPTION
## Summary

Closes the two open Dependabot alerts on the default branch by adding an npm `overrides` entry that forces `serialize-javascript` to `^7.0.5`. The vulnerable `6.0.2` is pulled in transitively by `@wordpress/scripts` -> `copy-webpack-plugin@10.2.4` (and `terser-webpack-plugin@5.3.16` dedups onto it).

- [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) — **high**, RCE via `RegExp.flags` / `Date.toISOString`
- [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) — **medium**, CPU-exhaustion DoS via array-like objects

Both require `>= 7.x`; the `6.x` line has no fix release.

### Why an override and not a `@wordpress/scripts` major bump?

I tried bumping `@wordpress/scripts` to `^32.1.0` first. It ships `@wordpress/eslint-plugin@25`, which changes the prettier defaults that wp-scripts' bundled `lint-js` runner picks up — running `npm run lint:js` after the bump produced ~600 unrelated whitespace errors across `src/` (parens-with-spaces, etc.). That's a much bigger PR than this security fix needs to be, and the formatting-rule migration belongs in its own change.

Sticking with the existing `@wordpress/scripts@^31.2.0` resolution and overriding only the offending transitive package is the minimum surface change.

### Engine bump

`serialize-javascript@7` declares `engines.node >= 20.0.0`, so I bumped `engines.node` (and `engines.npm`) to match. CI already runs on Node 20 (`.github/workflows/ci.yml`), so no CI work needed.

## Test plan

- [x] `composer run lint` — clean
- [x] `composer run test` — 453 tests pass
- [x] `composer run phpstan` — no errors
- [x] `npm run lint:js` — clean
- [x] `npm run build` — webpack compiled successfully
- [x] `npm ls serialize-javascript` shows `7.0.5 overridden`
- [ ] After merge, confirm both Dependabot alerts auto-close.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated minimum required versions: Node.js (v20.0.0) and npm (v10.0.0)
* Updated dependency pinning for compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->