### PR TITLE
Add ETA to import progress (F4.2)

### DIFF
--- a/includes/Processor/ImportProcessor.php
+++ b/includes/Processor/ImportProcessor.php
@@ -154,6 +154,12 @@ class ImportProcessor {
 			return;
 		}
 
+		// Record when processing actually began so progress ETA can be computed.
+		if ( empty( $batch['started_at'] ) ) {
+			$batch['started_at'] = gmdate( 'c' );
+			update_option( 'ai_importer_batch_' . $batch_id, $batch, false );
+		}
+
 		$adapter = AdapterRegistry::get_instance()->get( $batch['source_adapter'] );
 
 		if ( ! $adapter ) {

--- a/includes/REST/ImportsController.php
+++ b/includes/REST/ImportsController.php
@@ -245,7 +245,7 @@ class ImportsController extends WP_REST_Controller {
 			'failed'         => 0,
 			'errors'         => array(),
 			'created_at'     => $now,
-			'started_at'     => $now,
+			'started_at'     => null,
 			'completed_at'   => null,
 			'imported_ids'   => array(),
 		);
@@ -425,19 +425,74 @@ class ImportsController extends WP_REST_Controller {
 			'rolled_back' => __( 'Rolled Back', 'ai-importer' ),
 		);
 
+		$eta = self::calculate_eta( $batch );
+
 		return array(
-			'id'             => $batch['id'],
-			'source_adapter' => $batch['source_adapter'],
-			'state'          => $batch['state'],
-			'state_label'    => $state_labels[ $batch['state'] ] ?? $batch['state'],
-			'total'          => $total,
-			'processed'      => $processed,
-			'failed'         => (int) $batch['failed'],
-			'percentage'     => $percentage,
-			'created_at'     => $batch['created_at'],
-			'started_at'     => $batch['started_at'] ?? null,
-			'completed_at'   => $batch['completed_at'] ?? null,
-			'errors'         => array_slice( $batch['errors'] ?? array(), -50 ),
+			'id'               => $batch['id'],
+			'source_adapter'   => $batch['source_adapter'],
+			'state'            => $batch['state'],
+			'state_label'      => $state_labels[ $batch['state'] ] ?? $batch['state'],
+			'total'            => $total,
+			'processed'        => $processed,
+			'failed'           => (int) $batch['failed'],
+			'percentage'       => $percentage,
+			'created_at'       => $batch['created_at'],
+			'started_at'       => $batch['started_at'] ?? null,
+			'completed_at'     => $batch['completed_at'] ?? null,
+			'items_per_minute' => $eta['items_per_minute'],
+			'eta_seconds'      => $eta['eta_seconds'],
+			'errors'           => array_slice( $batch['errors'] ?? array(), -50 ),
+		);
+	}
+
+	/**
+	 * Calculate import throughput and estimated time remaining for a batch.
+	 *
+	 * The rate is based on successfully processed items versus elapsed time
+	 * since processing began. No estimate is returned when the batch is not
+	 * actively processing (paused, completed, failed, rolled back), when no
+	 * items have been processed yet, or when no started_at timestamp exists.
+	 *
+	 * @param array<string, mixed> $batch Raw batch data.
+	 * @param int|null             $now   Current Unix timestamp. Defaults to time().
+	 * @return array{items_per_minute: float|null, eta_seconds: int|null}
+	 */
+	public static function calculate_eta( array $batch, ?int $now = null ): array {
+		$none = array(
+			'items_per_minute' => null,
+			'eta_seconds'      => null,
+		);
+
+		if ( 'processing' !== ( $batch['state'] ?? '' ) ) {
+			return $none;
+		}
+
+		$processed = (int) ( $batch['processed'] ?? 0 );
+
+		if ( $processed <= 0 || empty( $batch['started_at'] ) ) {
+			return $none;
+		}
+
+		$started_at = strtotime( (string) $batch['started_at'] );
+
+		if ( false === $started_at ) {
+			return $none;
+		}
+
+		$now     = $now ?? time();
+		$elapsed = $now - $started_at;
+
+		if ( $elapsed <= 0 ) {
+			return $none;
+		}
+
+		$rate      = $processed / $elapsed;
+		$failed    = (int) ( $batch['failed'] ?? 0 );
+		$remaining = max( 0, (int) $batch['total'] - $processed - $failed );
+
+		return array(
+			'items_per_minute' => round( $rate * 60, 1 ),
+			'eta_seconds'      => (int) ceil( $remaining / $rate ),
 		);
 	}
 

--- a/src/components/ImportProgress.js
+++ b/src/components/ImportProgress.js
@@ -3,7 +3,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, _n, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Card,
@@ -17,6 +17,44 @@ import {
 	resumeImport,
 	rollbackImport,
 } from '../api';
+
+/**
+ * Format an ETA in seconds as a human-friendly string.
+ *
+ * @param {number} seconds Estimated seconds remaining.
+ * @return {string} Human-readable time remaining.
+ */
+function formatEta( seconds ) {
+	if ( seconds < 60 ) {
+		return __( 'less than a minute remaining', 'ai-importer' );
+	}
+
+	if ( seconds < 3600 ) {
+		const minutes = Math.round( seconds / 60 );
+		return sprintf(
+			/* translators: %d: number of minutes remaining. */
+			_n(
+				'about %d minute remaining',
+				'about %d minutes remaining',
+				minutes,
+				'ai-importer'
+			),
+			minutes
+		);
+	}
+
+	const hours = Math.round( seconds / 3600 );
+	return sprintf(
+		/* translators: %d: number of hours remaining. */
+		_n(
+			'about %d hour remaining',
+			'about %d hours remaining',
+			hours,
+			'ai-importer'
+		),
+		hours
+	);
+}
 
 /**
  * ImportProgress component shows real-time import status.
@@ -185,6 +223,22 @@ export default function ImportProgress( { batchId, onComplete } ) {
 								{ __( 'failed', 'ai-importer' ) }
 							</span>
 						) }
+						{ isActive &&
+							Number.isFinite( progress.eta_seconds ) && (
+								<span className="ai-importer-progress__eta">
+									{ formatEta( progress.eta_seconds ) }
+								</span>
+							) }
+						{ isActive &&
+							Number.isFinite( progress.items_per_minute ) && (
+								<span className="ai-importer-progress__rate">
+									{ sprintf(
+										/* translators: %s: number of items imported per minute. */
+										__( '%s items/min', 'ai-importer' ),
+										progress.items_per_minute
+									) }
+								</span>
+							) }
 					</div>
 
 					{ progress.errors?.length > 0 && (

--- a/tests/Unit/Processor/ImportProcessorTest.php
+++ b/tests/Unit/Processor/ImportProcessorTest.php
@@ -298,6 +298,64 @@ class ImportProcessorTest extends TestCase {
 	}
 
 	/**
+	 * Test process_batch records started_at when processing begins.
+	 *
+	 * @return void
+	 */
+	public function test_process_batch_records_started_at(): void {
+		$this->register_mock_adapter();
+
+		$creator = Mockery::mock( ContentCreator::class );
+		$creator->shouldReceive( 'create' )->andReturn( 100 );
+
+		$media_handler = Mockery::mock( MediaHandler::class );
+		$media_handler->shouldReceive( 'process' )->andReturn( array() );
+
+		$normalizer = $this->create_mock_normalizer();
+
+		Filters\expectApplied( 'ai_importer_normalizers' )
+			->andReturn( array( 'twitter' => $normalizer ) );
+
+		$this->store_batch( 'batch-1', 'processing', array( 'item-1' ) );
+		$this->options['ai_importer_batch_batch-1']['started_at'] = null;
+
+		$processor = new ImportProcessor( $creator, $media_handler );
+		$processor->process_batch( 'batch-1' );
+
+		$batch = $this->options['ai_importer_batch_batch-1'];
+		$this->assertNotEmpty( $batch['started_at'] );
+		$this->assertNotFalse( strtotime( $batch['started_at'] ) );
+	}
+
+	/**
+	 * Test process_batch preserves an existing started_at timestamp.
+	 *
+	 * @return void
+	 */
+	public function test_process_batch_preserves_existing_started_at(): void {
+		$this->register_mock_adapter();
+
+		$creator = Mockery::mock( ContentCreator::class );
+		$creator->shouldReceive( 'create' )->andReturn( 100 );
+
+		$media_handler = Mockery::mock( MediaHandler::class );
+		$media_handler->shouldReceive( 'process' )->andReturn( array() );
+
+		$normalizer = $this->create_mock_normalizer();
+
+		Filters\expectApplied( 'ai_importer_normalizers' )
+			->andReturn( array( 'twitter' => $normalizer ) );
+
+		$this->store_batch( 'batch-1', 'processing', array( 'item-1' ) );
+
+		$processor = new ImportProcessor( $creator, $media_handler );
+		$processor->process_batch( 'batch-1' );
+
+		$batch = $this->options['ai_importer_batch_batch-1'];
+		$this->assertSame( '2024-01-15T10:00:00+00:00', $batch['started_at'] );
+	}
+
+	/**
 	 * Store a test batch in the in-memory options.
 	 *
 	 * @param string        $id       Batch ID.

--- a/tests/Unit/REST/ImportsControllerTest.php
+++ b/tests/Unit/REST/ImportsControllerTest.php
@@ -331,6 +331,177 @@ class ImportsControllerTest extends TestCase {
 	}
 
 	/**
+	 * Test calculate_eta computes throughput and remaining time.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_computes_rate_and_eta(): void {
+		$started_at = '2024-01-15T10:00:00+00:00';
+		$now        = strtotime( $started_at ) + 60;
+
+		$batch = $this->make_eta_batch( 'processing', 20, 5, 1, $started_at );
+
+		$eta = ImportsController::calculate_eta( $batch, $now );
+
+		// 5 items in 60 seconds = 5 items/minute.
+		$this->assertSame( 5.0, $eta['items_per_minute'] );
+		// 14 items remaining at 5/min = 168 seconds.
+		$this->assertSame( 168, $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test calculate_eta returns null when nothing has been processed yet.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_zero_processed(): void {
+		$batch = $this->make_eta_batch( 'processing', 20, 0, 0, '2024-01-15T10:00:00+00:00' );
+
+		$eta = ImportsController::calculate_eta( $batch, strtotime( '2024-01-15T10:05:00+00:00' ) );
+
+		$this->assertNull( $eta['items_per_minute'] );
+		$this->assertNull( $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test calculate_eta returns null for paused batches.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_paused_batch(): void {
+		$batch = $this->make_eta_batch( 'paused', 20, 5, 0, '2024-01-15T10:00:00+00:00' );
+
+		$eta = ImportsController::calculate_eta( $batch, strtotime( '2024-01-15T10:01:00+00:00' ) );
+
+		$this->assertNull( $eta['items_per_minute'] );
+		$this->assertNull( $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test calculate_eta returns null for completed batches.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_completed_batch(): void {
+		$batch = $this->make_eta_batch( 'completed', 20, 20, 0, '2024-01-15T10:00:00+00:00' );
+
+		$eta = ImportsController::calculate_eta( $batch, strtotime( '2024-01-15T10:10:00+00:00' ) );
+
+		$this->assertNull( $eta['items_per_minute'] );
+		$this->assertNull( $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test calculate_eta returns null when started_at is missing.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_missing_started_at(): void {
+		$batch = $this->make_eta_batch( 'processing', 20, 5, 0, null );
+
+		$eta = ImportsController::calculate_eta( $batch, strtotime( '2024-01-15T10:01:00+00:00' ) );
+
+		$this->assertNull( $eta['items_per_minute'] );
+		$this->assertNull( $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test calculate_eta returns null when no time has elapsed.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_zero_elapsed(): void {
+		$started_at = '2024-01-15T10:00:00+00:00';
+		$batch      = $this->make_eta_batch( 'processing', 20, 5, 0, $started_at );
+
+		$eta = ImportsController::calculate_eta( $batch, strtotime( $started_at ) );
+
+		$this->assertNull( $eta['items_per_minute'] );
+		$this->assertNull( $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test calculate_eta returns zero remaining when all items are handled.
+	 *
+	 * @return void
+	 */
+	public function test_calculate_eta_all_items_handled(): void {
+		$started_at = '2024-01-15T10:00:00+00:00';
+		$batch      = $this->make_eta_batch( 'processing', 10, 8, 2, $started_at );
+
+		$eta = ImportsController::calculate_eta( $batch, strtotime( $started_at ) + 60 );
+
+		$this->assertSame( 8.0, $eta['items_per_minute'] );
+		$this->assertSame( 0, $eta['eta_seconds'] );
+	}
+
+	/**
+	 * Test serialized batch includes ETA fields.
+	 *
+	 * @return void
+	 */
+	public function test_get_item_includes_eta_fields(): void {
+		$this->create_test_batch( 'test-uuid-1234', 'processing', array(), 10, 5 );
+
+		$request             = new WP_REST_Request( 'GET', '/ai-importer/v1/imports/test-uuid-1234' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->get_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertArrayHasKey( 'items_per_minute', $result );
+		$this->assertArrayHasKey( 'eta_seconds', $result );
+		// Batch is processing with processed items and a past started_at,
+		// so server-computed values must be present.
+		$this->assertNotNull( $result['items_per_minute'] );
+		$this->assertNotNull( $result['eta_seconds'] );
+	}
+
+	/**
+	 * Test serialized batch returns null ETA fields when not computable.
+	 *
+	 * @return void
+	 */
+	public function test_get_item_eta_fields_null_when_unavailable(): void {
+		// No processed items yet.
+		$this->create_test_batch( 'test-uuid-1234', 'processing', array(), 10, 0 );
+
+		$request             = new WP_REST_Request( 'GET', '/ai-importer/v1/imports/test-uuid-1234' );
+		$request['batch_id'] = 'test-uuid-1234';
+		$response            = $this->controller->get_item( $request );
+		$result              = $response->get_data();
+
+		$this->assertNull( $result['items_per_minute'] );
+		$this->assertNull( $result['eta_seconds'] );
+	}
+
+	/**
+	 * Build a minimal batch array for calculate_eta tests.
+	 *
+	 * @param string      $state      Batch state.
+	 * @param int         $total      Total items.
+	 * @param int         $processed  Processed count.
+	 * @param int         $failed     Failed count.
+	 * @param string|null $started_at Started timestamp (ISO 8601) or null.
+	 * @return array<string, mixed>
+	 */
+	private function make_eta_batch(
+		string $state,
+		int $total,
+		int $processed,
+		int $failed,
+		?string $started_at
+	): array {
+		return array(
+			'id'         => 'eta-batch',
+			'state'      => $state,
+			'total'      => $total,
+			'processed'  => $processed,
+			'failed'     => $failed,
+			'started_at' => $started_at,
+		);
+	}
+
+	/**
 	 * Register a mock adapter in the registry.
 	 *
 	 * @param string $id              Adapter ID.


### PR DESCRIPTION
Part of [#12](https://github.com/adamsilverstein/ai-importer/issues/12).

## What

Adds an estimated time remaining and throughput indicator to the import progress UI.

### Backend
- `ImportProcessor::process_batch()` now records `started_at` on the batch when Action Scheduler actually begins processing (it was previously set at batch creation), so elapsed time reflects real processing time even when the queue is delayed.
- `ImportsController` computes `items_per_minute` and `eta_seconds` server-side in a new `calculate_eta()` method and includes them in every serialized batch response. The rate is based on processed items vs. elapsed time since `started_at`; remaining items account for failures.
- Edge cases return `null` for both fields so the client can simply hide the estimate: no items processed yet, paused/completed/failed/rolled-back batches, missing or unparseable `started_at`, and zero elapsed time.

### Frontend
- `ImportProgress` renders the ETA as a human-friendly string ("about 4 minutes remaining", with minute/hour pluralization via `_n()") plus an "N items/min" throughput figure while the import is actively processing. Both are hidden when unavailable.

## Testing
- 9 new PHPUnit tests covering `calculate_eta()` (happy path, zero processed, paused, completed, missing `started_at`, zero elapsed, all items handled) and the serialized REST response, plus 2 tests verifying `started_at` is recorded once by the processor and preserved on subsequent runs.
- `composer run lint` (phpcs): clean.
- `./vendor/bin/phpunit`: 464 tests, 991 assertions, all passing (1 pre-existing deprecation in PluginTest, unrelated).
- `composer run phpstan`: no errors.
- `npm run lint:js` and `npm run build`: clean.