### PR TITLE
Add date range and engagement filters to content inventory (F2.5)

### DIFF
--- a/src/components/ContentReview.js
+++ b/src/components/ContentReview.js
@@ -3,7 +3,7 @@
  */
 
 import { useState, useMemo } from '@wordpress/element';
-import { __ } from '@wordpress/i18n';
+import { __, sprintf } from '@wordpress/i18n';
 import {
 	Button,
 	Card,
@@ -11,7 +11,15 @@ import {
 	CardHeader,
 	CheckboxControl,
 	SelectControl,
+	TextControl,
 } from '@wordpress/components';
+
+import {
+	computeHighEngagementThreshold,
+	filterManifestItems,
+	getEngagementCount,
+	hasEngagementData,
+} from '../utils/manifestFilters';
 
 /**
  * ContentReview component displays manifest items for selection.
@@ -31,13 +39,38 @@ export default function ContentReview( { manifest, onImport, isLoading } ) {
 			.map( ( item ) => item.id )
 	);
 	const [ typeFilter, setTypeFilter ] = useState( '' );
+	const [ dateFromFilter, setDateFromFilter ] = useState( '' );
+	const [ dateToFilter, setDateToFilter ] = useState( '' );
+	const [ engagementFilter, setEngagementFilter ] = useState( '' );
 
-	const filteredItems = useMemo( () => {
-		if ( ! typeFilter ) {
-			return manifest.items;
-		}
-		return manifest.items.filter( ( item ) => item.type === typeFilter );
-	}, [ manifest.items, typeFilter ] );
+	const showEngagementFilter = useMemo(
+		() => hasEngagementData( manifest.items ),
+		[ manifest.items ]
+	);
+
+	const highEngagementThreshold = useMemo(
+		() => computeHighEngagementThreshold( manifest.items ),
+		[ manifest.items ]
+	);
+
+	const filteredItems = useMemo(
+		() =>
+			filterManifestItems( manifest.items, {
+				type: typeFilter,
+				dateFrom: dateFromFilter,
+				dateTo: dateToFilter,
+				engagement: engagementFilter,
+				highEngagementThreshold,
+			} ),
+		[
+			manifest.items,
+			typeFilter,
+			dateFromFilter,
+			dateToFilter,
+			engagementFilter,
+			highEngagementThreshold,
+		]
+	);
 
 	const typeOptions = useMemo( () => {
 		const types = [
@@ -51,6 +84,24 @@ export default function ContentReview( { manifest, onImport, isLoading } ) {
 			} ) ),
 		];
 	}, [ manifest.items ] );
+
+	const engagementOptions = useMemo(
+		() => [
+			{ label: __( 'All engagement', 'ai-importer' ), value: '' },
+			{ label: __( 'Any engagement', 'ai-importer' ), value: 'any' },
+			{
+				label: highEngagementThreshold
+					? sprintf(
+							/* translators: %d: engagement count threshold. */
+							__( 'High engagement (%d+)', 'ai-importer' ),
+							highEngagementThreshold
+					  )
+					: __( 'High engagement', 'ai-importer' ),
+				value: 'high',
+			},
+		],
+		[ highEngagementThreshold ]
+	);
 
 	const mediaCount = useMemo(
 		() =>
@@ -168,12 +219,40 @@ export default function ContentReview( { manifest, onImport, isLoading } ) {
 								{ __( 'selected', 'ai-importer' ) })
 							</span>
 						</h2>
-						<SelectControl
-							value={ typeFilter }
-							options={ typeOptions }
-							onChange={ setTypeFilter }
-							__nextHasNoMarginBottom
-						/>
+						<div className="ai-importer-content-review__filters">
+							<SelectControl
+								label={ __( 'Type', 'ai-importer' ) }
+								value={ typeFilter }
+								options={ typeOptions }
+								onChange={ setTypeFilter }
+								__nextHasNoMarginBottom
+							/>
+							<TextControl
+								label={ __( 'From date', 'ai-importer' ) }
+								type="date"
+								value={ dateFromFilter }
+								onChange={ setDateFromFilter }
+								max={ dateToFilter || undefined }
+								__nextHasNoMarginBottom
+							/>
+							<TextControl
+								label={ __( 'To date', 'ai-importer' ) }
+								type="date"
+								value={ dateToFilter }
+								onChange={ setDateToFilter }
+								min={ dateFromFilter || undefined }
+								__nextHasNoMarginBottom
+							/>
+							{ showEngagementFilter && (
+								<SelectControl
+									label={ __( 'Engagement', 'ai-importer' ) }
+									value={ engagementFilter }
+									options={ engagementOptions }
+									onChange={ setEngagementFilter }
+									__nextHasNoMarginBottom
+								/>
+							) }
+						</div>
 					</div>
 				</CardHeader>
 				<CardBody>
@@ -219,10 +298,27 @@ export default function ContentReview( { manifest, onImport, isLoading } ) {
 												{ __( 'media', 'ai-importer' ) }
 											</span>
 										) }
+										{ getEngagementCount( item ) > 0 && (
+											<span className="ai-importer-content-review__item-engagement">
+												{ getEngagementCount( item ) }{ ' ' }
+												{ __(
+													'engagement',
+													'ai-importer'
+												) }
+											</span>
+										) }
 									</span>
 								</div>
 							</div>
 						) ) }
+						{ filteredItems.length === 0 && (
+							<p className="ai-importer-content-review__empty">
+								{ __(
+									'No items match the current filters.',
+									'ai-importer'
+								) }
+							</p>
+						) }
 						{ filteredItems.length > 100 && (
 							<p className="ai-importer-content-review__truncated">
 								{ __(

--- a/src/style.scss
+++ b/src/style.scss
@@ -233,8 +233,17 @@
 	&__toolbar {
 		display: flex;
 		justify-content: space-between;
-		align-items: center;
+		align-items: flex-start;
+		gap: 16px;
+		flex-wrap: wrap;
 		width: 100%;
+	}
+
+	&__filters {
+		display: flex;
+		gap: 12px;
+		align-items: flex-end;
+		flex-wrap: wrap;
 	}
 
 	&__count {
@@ -284,7 +293,8 @@
 		text-transform: capitalize;
 	}
 
-	&__truncated {
+	&__truncated,
+	&__empty {
 		padding: 12px 0;
 		color: #757575;
 		font-style: italic;

--- a/src/utils/manifestFilters.js
+++ b/src/utils/manifestFilters.js
@@ -1,0 +1,165 @@
+/**
+ * Client-side filtering helpers for manifest items.
+ *
+ * Manifest items are plain objects from the REST API with the shape
+ * produced by ManifestItem::to_array(): id, type, title, excerpt,
+ * created_at (ISO 8601 string), media_urls, metadata, etc.
+ */
+
+/**
+ * Metadata keys that represent engagement counts on the source platform.
+ *
+ * Adapters store platform-specific engagement numbers in item metadata,
+ * e.g. the Twitter adapter provides `favorite_count` and `retweet_count`.
+ *
+ * @type {string[]}
+ */
+const ENGAGEMENT_KEYS = [
+	'favorite_count',
+	'retweet_count',
+	'like_count',
+	'likes',
+	'reply_count',
+	'replies',
+	'reblog_count',
+	'comment_count',
+	'claps',
+	'note_count',
+];
+
+/**
+ * Get the total engagement count for a manifest item.
+ *
+ * Sums all known engagement metadata keys. Returns null when the item
+ * carries no engagement metadata at all, which distinguishes "no data"
+ * from an item with zero engagement.
+ *
+ * @param {Object} item Manifest item.
+ * @return {?number} Total engagement count, or null if no engagement data.
+ */
+export function getEngagementCount( item ) {
+	const metadata = item?.metadata;
+
+	if ( ! metadata || typeof metadata !== 'object' ) {
+		return null;
+	}
+
+	let found = false;
+	let total = 0;
+
+	for ( const key of ENGAGEMENT_KEYS ) {
+		const value = metadata[ key ];
+
+		if ( typeof value === 'number' && isFinite( value ) ) {
+			found = true;
+			total += value;
+		}
+	}
+
+	return found ? total : null;
+}
+
+/**
+ * Check whether any item in a list carries engagement metadata.
+ *
+ * @param {Object[]} items Manifest items.
+ * @return {boolean} True if at least one item has engagement data.
+ */
+export function hasEngagementData( items ) {
+	return ( items || [] ).some(
+		( item ) => getEngagementCount( item ) !== null
+	);
+}
+
+/**
+ * Compute the "high engagement" threshold for a set of items.
+ *
+ * Uses the 75th percentile of engagement counts across items that carry
+ * engagement data, with a minimum threshold of 1.
+ *
+ * @param {Object[]} items Manifest items.
+ * @return {?number} Threshold, or null when no items have engagement data.
+ */
+export function computeHighEngagementThreshold( items ) {
+	const counts = ( items || [] )
+		.map( getEngagementCount )
+		.filter( ( count ) => count !== null )
+		.sort( ( a, b ) => a - b );
+
+	if ( counts.length === 0 ) {
+		return null;
+	}
+
+	const index = Math.min(
+		Math.floor( counts.length * 0.75 ),
+		counts.length - 1
+	);
+
+	return Math.max( 1, counts[ index ] );
+}
+
+/**
+ * Filter manifest items by type, date range, and engagement level.
+ *
+ * All provided filters are combined with AND logic. Date comparisons use
+ * the date portion of the item's ISO 8601 created_at string, so they match
+ * the date as recorded by the source platform.
+ *
+ * @param {Object[]} items                             Manifest items.
+ * @param {Object}   filters                           Active filters.
+ * @param {string}   [filters.type]                    Content type, or '' for all.
+ * @param {string}   [filters.dateFrom]                Inclusive start date (YYYY-MM-DD), or ''.
+ * @param {string}   [filters.dateTo]                  Inclusive end date (YYYY-MM-DD), or ''.
+ * @param {string}   [filters.engagement]              '' (all), 'any', or 'high'.
+ * @param {?number}  [filters.highEngagementThreshold] Threshold for 'high'.
+ * @return {Object[]} Filtered items.
+ */
+export function filterManifestItems( items, filters = {} ) {
+	const {
+		type = '',
+		dateFrom = '',
+		dateTo = '',
+		engagement = '',
+		highEngagementThreshold = null,
+	} = filters;
+
+	return ( items || [] ).filter( ( item ) => {
+		if ( type && item.type !== type ) {
+			return false;
+		}
+
+		if ( dateFrom || dateTo ) {
+			const itemDate = ( item.created_at || '' ).slice( 0, 10 );
+
+			if ( ! itemDate ) {
+				return false;
+			}
+
+			if ( dateFrom && itemDate < dateFrom ) {
+				return false;
+			}
+
+			if ( dateTo && itemDate > dateTo ) {
+				return false;
+			}
+		}
+
+		if ( engagement ) {
+			const count = getEngagementCount( item );
+
+			if ( 'any' === engagement && ! ( count > 0 ) ) {
+				return false;
+			}
+
+			if ( 'high' === engagement ) {
+				const threshold = highEngagementThreshold ?? 1;
+
+				if ( null === count || count < threshold ) {
+					return false;
+				}
+			}
+		}
+
+		return true;
+	} );
+}

--- a/src/utils/manifestFilters.test.js
+++ b/src/utils/manifestFilters.test.js
@@ -1,0 +1,212 @@
+/**
+ * Tests for manifest filtering helpers.
+ */
+
+import {
+	computeHighEngagementThreshold,
+	filterManifestItems,
+	getEngagementCount,
+	hasEngagementData,
+} from './manifestFilters';
+
+const makeItem = ( overrides = {} ) => ( {
+	id: 'item-1',
+	type: 'post',
+	title: 'Test item',
+	created_at: '2024-01-15T10:30:00+00:00',
+	media_urls: [],
+	metadata: {},
+	...overrides,
+} );
+
+describe( 'getEngagementCount', () => {
+	it( 'returns null when the item has no engagement metadata', () => {
+		expect( getEngagementCount( makeItem() ) ).toBeNull();
+		expect(
+			getEngagementCount(
+				makeItem( { metadata: { tags: [ 'a' ], is_draft: false } } )
+			)
+		).toBeNull();
+	} );
+
+	it( 'returns null when metadata is missing entirely', () => {
+		expect( getEngagementCount( { id: 'x' } ) ).toBeNull();
+		expect(
+			getEngagementCount( makeItem( { metadata: null } ) )
+		).toBeNull();
+	} );
+
+	it( 'sums known engagement keys', () => {
+		const item = makeItem( {
+			metadata: { favorite_count: 10, retweet_count: 5 },
+		} );
+		expect( getEngagementCount( item ) ).toBe( 15 );
+	} );
+
+	it( 'returns zero (not null) when engagement keys exist with zero values', () => {
+		const item = makeItem( {
+			metadata: { favorite_count: 0, retweet_count: 0 },
+		} );
+		expect( getEngagementCount( item ) ).toBe( 0 );
+	} );
+
+	it( 'ignores non-numeric values', () => {
+		const item = makeItem( { metadata: { likes: 'lots' } } );
+		expect( getEngagementCount( item ) ).toBeNull();
+	} );
+} );
+
+describe( 'hasEngagementData', () => {
+	it( 'returns false for items without engagement metadata', () => {
+		expect( hasEngagementData( [ makeItem(), makeItem() ] ) ).toBe( false );
+		expect( hasEngagementData( [] ) ).toBe( false );
+	} );
+
+	it( 'returns true when at least one item has engagement metadata', () => {
+		const items = [
+			makeItem(),
+			makeItem( { metadata: { favorite_count: 0 } } ),
+		];
+		expect( hasEngagementData( items ) ).toBe( true );
+	} );
+} );
+
+describe( 'computeHighEngagementThreshold', () => {
+	it( 'returns null when no items carry engagement data', () => {
+		expect( computeHighEngagementThreshold( [ makeItem() ] ) ).toBeNull();
+		expect( computeHighEngagementThreshold( [] ) ).toBeNull();
+	} );
+
+	it( 'returns the 75th percentile of engagement counts', () => {
+		const items = [ 1, 2, 3, 4 ].map( ( count, i ) =>
+			makeItem( {
+				id: `item-${ i }`,
+				metadata: { favorite_count: count },
+			} )
+		);
+		expect( computeHighEngagementThreshold( items ) ).toBe( 4 );
+	} );
+
+	it( 'enforces a minimum threshold of 1', () => {
+		const items = [
+			makeItem( { metadata: { favorite_count: 0 } } ),
+			makeItem( { id: 'item-2', metadata: { favorite_count: 0 } } ),
+		];
+		expect( computeHighEngagementThreshold( items ) ).toBe( 1 );
+	} );
+} );
+
+describe( 'filterManifestItems', () => {
+	const items = [
+		makeItem( {
+			id: 'tweet-1',
+			type: 'post',
+			created_at: '2023-06-01T08:00:00+00:00',
+			metadata: { favorite_count: 2, retweet_count: 0 },
+		} ),
+		makeItem( {
+			id: 'tweet-2',
+			type: 'reply',
+			created_at: '2024-01-15T10:30:00+00:00',
+			metadata: { favorite_count: 0, retweet_count: 0 },
+		} ),
+		makeItem( {
+			id: 'tweet-3',
+			type: 'post',
+			created_at: '2024-03-20T23:59:00+00:00',
+			metadata: { favorite_count: 90, retweet_count: 10 },
+		} ),
+		makeItem( {
+			id: 'blog-1',
+			type: 'article',
+			created_at: '2025-02-10T12:00:00+00:00',
+		} ),
+	];
+
+	it( 'returns all items when no filters are set', () => {
+		expect( filterManifestItems( items ) ).toHaveLength( 4 );
+		expect( filterManifestItems( items, {} ) ).toHaveLength( 4 );
+	} );
+
+	it( 'filters by type', () => {
+		const result = filterManifestItems( items, { type: 'post' } );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [
+			'tweet-1',
+			'tweet-3',
+		] );
+	} );
+
+	it( 'filters by from date inclusively', () => {
+		const result = filterManifestItems( items, {
+			dateFrom: '2024-01-15',
+		} );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [
+			'tweet-2',
+			'tweet-3',
+			'blog-1',
+		] );
+	} );
+
+	it( 'filters by to date inclusively', () => {
+		const result = filterManifestItems( items, { dateTo: '2024-01-15' } );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [
+			'tweet-1',
+			'tweet-2',
+		] );
+	} );
+
+	it( 'filters by a combined date range', () => {
+		const result = filterManifestItems( items, {
+			dateFrom: '2024-01-01',
+			dateTo: '2024-12-31',
+		} );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [
+			'tweet-2',
+			'tweet-3',
+		] );
+	} );
+
+	it( 'excludes items without a created_at date when a date filter is set', () => {
+		const undated = makeItem( { id: 'undated', created_at: '' } );
+		const result = filterManifestItems( [ ...items, undated ], {
+			dateFrom: '2000-01-01',
+		} );
+		expect( result.map( ( i ) => i.id ) ).not.toContain( 'undated' );
+	} );
+
+	it( 'filters by any engagement', () => {
+		const result = filterManifestItems( items, { engagement: 'any' } );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [
+			'tweet-1',
+			'tweet-3',
+		] );
+	} );
+
+	it( 'filters by high engagement using the threshold', () => {
+		const result = filterManifestItems( items, {
+			engagement: 'high',
+			highEngagementThreshold: 50,
+		} );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [ 'tweet-3' ] );
+	} );
+
+	it( 'excludes items without engagement data from engagement filters', () => {
+		const any = filterManifestItems( items, { engagement: 'any' } );
+		const high = filterManifestItems( items, {
+			engagement: 'high',
+			highEngagementThreshold: 1,
+		} );
+		expect( any.map( ( i ) => i.id ) ).not.toContain( 'blog-1' );
+		expect( high.map( ( i ) => i.id ) ).not.toContain( 'blog-1' );
+	} );
+
+	it( 'combines type, date, and engagement filters with AND logic', () => {
+		const result = filterManifestItems( items, {
+			type: 'post',
+			dateFrom: '2024-01-01',
+			dateTo: '2024-12-31',
+			engagement: 'any',
+		} );
+		expect( result.map( ( i ) => i.id ) ).toEqual( [ 'tweet-3' ] );
+	} );
+} );


### PR DESCRIPTION
Part of #10 (https://github.com/adamsilverstein/ai-importer/issues/10)

## What

Adds date range and engagement level filtering to the content review step of the import wizard, completing the F2.5 filtering requirements (type, date, engagement) for the content inventory.

- New `src/utils/manifestFilters.js` module with pure, unit-tested helpers:
  - `filterManifestItems()` combines type, from/to date, and engagement filters with AND logic, operating client-side over the already-loaded manifest items (consistent with the existing type filter).
  - `getEngagementCount()` derives a per-item engagement total from adapter-provided metadata keys (e.g. the Twitter adapter's `favorite_count` and `retweet_count`), returning `null` when an item carries no engagement data.
  - `computeHighEngagementThreshold()` picks the "high engagement" cutoff as the 75th percentile of available engagement counts (minimum 1).
- `ContentReview` toolbar gains labeled From date / To date inputs (`TextControl type="date"`) and an Engagement dropdown (All / Any engagement / High engagement with the computed threshold shown in the label).
- The engagement filter is hidden gracefully when no manifest items carry engagement metadata (e.g. Medium, Blogger, Instagram exports), since only some adapters provide engagement counts.
- Per-item engagement counts are shown in the item meta row, and an empty-state message appears when no items match the active filters.
- No PHP changes were needed: engagement metadata already flows through `ManifestItem::to_array()` into the REST manifest response where adapters provide it.

## Date semantics

Date comparisons use the date portion of each item's ISO 8601 `created_at` string, so filtering matches the date as recorded by the source platform; both bounds are inclusive.

## Testing

- Added `src/utils/manifestFilters.test.js` with 20 Jest unit tests covering engagement extraction, threshold computation, each filter individually, inclusive date bounds, missing-data edge cases, and combined AND filtering - all passing via `wp-scripts test-unit-js`.
- `npm run lint` (JS + CSS) passes.
- `npm run build` compiles successfully.