### PR TITLE
Add mapping configuration screen and saved mappings (F3.4, F3.5, F6.3)

### DIFF
--- a/includes/Processor/ContentCreator.php
+++ b/includes/Processor/ContentCreator.php
@@ -50,21 +50,22 @@ class ContentCreator {
 	/**
 	 * Create a WordPress post from a normalized item.
 	 *
-	 * @param NormalizedItem $item     The normalized content.
-	 * @param string         $batch_id The import batch UUID.
+	 * @param NormalizedItem       $item     The normalized content.
+	 * @param string               $batch_id The import batch UUID.
+	 * @param array<string, mixed> $mapping  Optional mapping configuration (see MappingConfig).
 	 * @return int The created post ID.
 	 * @throws RuntimeException On wp_insert_post failure.
 	 */
-	public function create( NormalizedItem $item, string $batch_id ): int {
+	public function create( NormalizedItem $item, string $batch_id, array $mapping = array() ): int {
 		$gmt_date = $item->publish_date->setTimezone( new DateTimeZone( 'UTC' ) );
 
 		$post_args = array(
 			'post_title'    => $item->title ? $item->title : $item->generate_title(),
 			'post_content'  => $item->content,
-			'post_status'   => 'draft',
+			'post_status'   => $this->resolve_post_status( $mapping ),
 			'post_date'     => $item->publish_date->format( 'Y-m-d H:i:s' ),
 			'post_date_gmt' => $gmt_date->format( 'Y-m-d H:i:s' ),
-			'post_type'     => 'post',
+			'post_type'     => $this->resolve_post_type( $item, $mapping ),
 		);
 
 		/**
@@ -105,8 +106,12 @@ class ContentCreator {
 			update_post_meta( $post_id, self::META_SEO_DESCRIPTION, $item->metadata[ $seo_key ] );
 		}
 
-		// Set tags from hashtags.
-		if ( $item->has_tags() ) {
+		// Apply taxonomy mappings; default hashtag handling applies unless
+		// a mapping explicitly routes hashtags elsewhere.
+		$hashtags_handled = $this->apply_taxonomy_mappings( $post_id, $item, $mapping );
+
+		// Set tags from hashtags (default behavior).
+		if ( ! $hashtags_handled && $item->has_tags() ) {
 			wp_set_post_tags( $post_id, $item->tags );
 		}
 
@@ -127,5 +132,100 @@ class ContentCreator {
 		do_action( 'ai_importer_post_created', $post_id, $item, $batch_id );
 
 		return $post_id;
+	}
+
+	/**
+	 * Resolve the destination post type for an item.
+	 *
+	 * Per-content-type overrides from the mapping win over the mapping's
+	 * default post type, which wins over the built-in 'post' default.
+	 *
+	 * @param NormalizedItem       $item    The normalized item.
+	 * @param array<string, mixed> $mapping Mapping configuration.
+	 * @return string Post type slug.
+	 */
+	private function resolve_post_type( NormalizedItem $item, array $mapping ): string {
+		$post_type = 'post';
+
+		if ( ! empty( $mapping['post_type'] ) && is_string( $mapping['post_type'] ) ) {
+			$post_type = $mapping['post_type'];
+		}
+
+		if ( ! empty( $mapping['post_type_mappings'] ) && is_array( $mapping['post_type_mappings'] ) ) {
+			foreach ( $mapping['post_type_mappings'] as $entry ) {
+				if ( is_array( $entry )
+					&& isset( $entry['source_content_type'], $entry['destination_post_type'] )
+					&& $entry['source_content_type'] === $item->content_type->value
+					&& is_string( $entry['destination_post_type'] )
+					&& '' !== $entry['destination_post_type']
+				) {
+					$post_type = $entry['destination_post_type'];
+					break;
+				}
+			}
+		}
+
+		return $post_type;
+	}
+
+	/**
+	 * Resolve the post status from the mapping, defaulting to 'draft'.
+	 *
+	 * @param array<string, mixed> $mapping Mapping configuration.
+	 * @return string Post status.
+	 */
+	private function resolve_post_status( array $mapping ): string {
+		if ( ! empty( $mapping['post_status'] ) && is_string( $mapping['post_status'] ) ) {
+			return $mapping['post_status'];
+		}
+
+		return 'draft';
+	}
+
+	/**
+	 * Apply configured taxonomy mappings to a created post.
+	 *
+	 * A mapping with source_signal "hashtags" assigns the item's tags to
+	 * the destination taxonomy (taking over default hashtag handling).
+	 * Other mappings assign their fixed destination_terms.
+	 *
+	 * @param int                  $post_id The created post ID.
+	 * @param NormalizedItem       $item    The normalized item.
+	 * @param array<string, mixed> $mapping Mapping configuration.
+	 * @return bool True when a mapping handled the item's hashtags.
+	 */
+	private function apply_taxonomy_mappings( int $post_id, NormalizedItem $item, array $mapping ): bool {
+		if ( empty( $mapping['taxonomy_mappings'] ) || ! is_array( $mapping['taxonomy_mappings'] ) ) {
+			return false;
+		}
+
+		$hashtags_handled = false;
+
+		foreach ( $mapping['taxonomy_mappings'] as $entry ) {
+			if ( ! is_array( $entry )
+				|| empty( $entry['source_signal'] )
+				|| empty( $entry['destination_taxonomy'] )
+				|| ! is_string( $entry['destination_taxonomy'] )
+			) {
+				continue;
+			}
+
+			if ( 'hashtags' === $entry['source_signal'] ) {
+				$hashtags_handled = true;
+				$terms            = $item->tags;
+			} else {
+				$terms = isset( $entry['destination_terms'] ) && is_array( $entry['destination_terms'] )
+					? $entry['destination_terms']
+					: array();
+			}
+
+			if ( empty( $terms ) ) {
+				continue;
+			}
+
+			wp_set_object_terms( $post_id, $terms, $entry['destination_taxonomy'], true );
+		}
+
+		return $hashtags_handled;
 	}
 }

--- a/includes/Processor/ImportProcessor.php
+++ b/includes/Processor/ImportProcessor.php
@@ -191,6 +191,9 @@ class ImportProcessor {
 		$processed  = 0;
 		$offset     = (int) $batch['processed'] + (int) $batch['failed'];
 
+		// Optional mapping configuration attached when the batch was created.
+		$mapping = isset( $batch['mapping'] ) && is_array( $batch['mapping'] ) ? $batch['mapping'] : array();
+
 		while ( $processed < self::CHUNK_SIZE && ( time() - $start_time ) < self::TIME_LIMIT ) {
 			$index = $offset + $processed;
 
@@ -227,8 +230,8 @@ class ImportProcessor {
 					);
 				}
 
-				// Create the WordPress post.
-				$post_id = $this->creator->create( $normalized, $batch_id );
+				// Create the WordPress post, applying any mapping config.
+				$post_id = $this->creator->create( $normalized, $batch_id, $mapping );
 
 				++$batch['processed'];
 				$batch['imported_ids'][] = $post_id;

--- a/includes/REST/ImportsController.php
+++ b/includes/REST/ImportsController.php
@@ -8,6 +8,7 @@
 namespace AI_Importer\REST;
 
 use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Schema\MappingConfig;
 use WP_Error;
 use WP_REST_Controller;
 use WP_REST_Request;
@@ -81,6 +82,13 @@ class ImportsController extends WP_REST_Controller {
 							'required' => true,
 							'type'     => 'array',
 							'items'    => array( 'type' => 'string' ),
+						),
+						'mapping'        => array_merge(
+							array(
+								'required'    => false,
+								'description' => __( 'Mapping configuration to apply to imported content.', 'ai-importer' ),
+							),
+							MappingConfig::get_schema()
 						),
 					),
 				),
@@ -235,11 +243,16 @@ class ImportsController extends WP_REST_Controller {
 		$batch_id = wp_generate_uuid4();
 		$now      = gmdate( 'c' );
 
+		// Optional mapping configuration applied when creating posts.
+		$mapping = $request->get_param( 'mapping' );
+		$mapping = is_array( $mapping ) ? MappingConfig::sanitize( $mapping ) : array();
+
 		$batch = array(
 			'id'             => $batch_id,
 			'source_adapter' => $source_adapter,
 			'state'          => 'processing',
 			'item_ids'       => $item_ids,
+			'mapping'        => $mapping,
 			'total'          => count( $item_ids ),
 			'processed'      => 0,
 			'failed'         => 0,

--- a/includes/REST/SourcesController.php
+++ b/includes/REST/SourcesController.php
@@ -11,6 +11,7 @@ use AI_Importer\Adapters\AdapterRegistry;
 use AI_Importer\AI\AIService;
 use AI_Importer\AI\ContentAnalyzer;
 use AI_Importer\AI\MappingSuggester;
+use AI_Importer\Schema\MappingConfig;
 use AI_Importer\Schema\SiteSchemaAnalyzer;
 use WP_Error;
 use WP_REST_Controller;
@@ -28,6 +29,8 @@ use WP_REST_Server;
  *   POST   /sources/{id}/disconnect              - Disconnect an adapter
  *   GET    /sources/{id}/manifest                - Fetch content manifest
  *   GET    /sources/{id}/mapping-suggestions     - Generate AI mapping suggestions
+ *   GET    /sources/{id}/mappings                - Get the saved mapping configuration
+ *   POST   /sources/{id}/mappings                - Save a mapping configuration
  */
 class SourcesController extends WP_REST_Controller {
 
@@ -200,6 +203,44 @@ class SourcesController extends WP_REST_Controller {
 							'minimum'           => 1,
 							'maximum'           => 50,
 							'sanitize_callback' => 'absint',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-zA-Z0-9_-]+)/mappings',
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_mapping' ),
+					'permission_callback' => array( $this, 'manage_permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'save_mapping' ),
+					'permission_callback' => array( $this, 'manage_permissions_check' ),
+					'args'                => array(
+						'id'      => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+						'mapping' => array_merge(
+							array(
+								'required'    => true,
+								'description' => __( 'Mapping configuration to save for reuse.', 'ai-importer' ),
+							),
+							MappingConfig::get_schema()
 						),
 					),
 				),
@@ -463,6 +504,75 @@ class SourcesController extends WP_REST_Controller {
 				'analysis'    => $analysis,
 				'site_schema' => $site_schema,
 				'suggestions' => $suggestions,
+			)
+		);
+	}
+
+	/**
+	 * Get the saved mapping configuration for a source.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function get_mapping( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		$mapping = get_option( MappingConfig::get_option_key( $adapter->get_id() ), null );
+
+		return rest_ensure_response(
+			array(
+				'source_id' => $adapter->get_id(),
+				'mapping'   => is_array( $mapping ) ? $mapping : null,
+			)
+		);
+	}
+
+	/**
+	 * Save a mapping configuration for a source.
+	 *
+	 * Stored in wp_options as ai_importer_mappings_{adapter_id} so it can
+	 * be reused across import runs (F3.5).
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function save_mapping( $request ): WP_REST_Response|WP_Error {
+		$adapter = $this->get_adapter( $request['id'] );
+
+		if ( is_wp_error( $adapter ) ) {
+			return $adapter;
+		}
+
+		$mapping = $request->get_param( 'mapping' );
+
+		if ( ! is_array( $mapping ) ) {
+			return new WP_Error(
+				'invalid_mapping',
+				__( 'A mapping configuration object is required.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$mapping = MappingConfig::sanitize( $mapping );
+
+		if ( empty( $mapping ) ) {
+			return new WP_Error(
+				'invalid_mapping',
+				__( 'The mapping configuration contains no valid fields.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		update_option( MappingConfig::get_option_key( $adapter->get_id() ), $mapping, false );
+
+		return rest_ensure_response(
+			array(
+				'source_id' => $adapter->get_id(),
+				'mapping'   => $mapping,
 			)
 		);
 	}

--- a/includes/Schema/MappingConfig.php
+++ b/includes/Schema/MappingConfig.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * Mapping configuration schema and sanitization.
+ *
+ * @package AI_Importer\Schema
+ */
+
+namespace AI_Importer\Schema;
+
+/**
+ * Describes the user-editable mapping configuration shape.
+ *
+ * The shape is derived from MappingSuggester output: a default destination
+ * post type and status, optional per-content-type post type overrides, and
+ * taxonomy mappings (source signal such as "hashtags" mapped to a
+ * destination taxonomy with optional fixed terms).
+ *
+ * Used by the saved-mappings REST endpoints, by POST /imports when a
+ * mapping is attached to a batch, and by ContentCreator when applying the
+ * mapping to created posts.
+ */
+class MappingConfig {
+
+	/**
+	 * Option key prefix for saved mappings.
+	 */
+	public const OPTION_PREFIX = 'ai_importer_mappings_';
+
+	/**
+	 * Allowed post statuses for imported content.
+	 *
+	 * @var array<string>
+	 */
+	public const ALLOWED_STATUSES = array( 'draft', 'publish', 'pending', 'private' );
+
+	/**
+	 * JSON schema for a mapping configuration, suitable for REST route args.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public static function get_schema(): array {
+		return array(
+			'type'                 => 'object',
+			'properties'           => array(
+				'post_type'          => array(
+					'type'        => 'string',
+					'description' => __( 'Default destination post type.', 'ai-importer' ),
+				),
+				'post_status'        => array(
+					'type'        => 'string',
+					'enum'        => self::ALLOWED_STATUSES,
+					'description' => __( 'Post status for imported content.', 'ai-importer' ),
+				),
+				'post_type_mappings' => array(
+					'type'        => 'array',
+					'description' => __( 'Per-content-type destination post type overrides.', 'ai-importer' ),
+					'items'       => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'source_content_type'   => array( 'type' => 'string' ),
+							'destination_post_type' => array( 'type' => 'string' ),
+						),
+						'required'             => array( 'source_content_type', 'destination_post_type' ),
+						'additionalProperties' => false,
+					),
+				),
+				'taxonomy_mappings'  => array(
+					'type'        => 'array',
+					'description' => __( 'Source signals mapped to destination taxonomies.', 'ai-importer' ),
+					'items'       => array(
+						'type'                 => 'object',
+						'properties'           => array(
+							'source_signal'        => array( 'type' => 'string' ),
+							'destination_taxonomy' => array( 'type' => 'string' ),
+							'destination_terms'    => array(
+								'type'  => 'array',
+								'items' => array( 'type' => 'string' ),
+							),
+						),
+						'required'             => array( 'source_signal', 'destination_taxonomy' ),
+						'additionalProperties' => false,
+					),
+				),
+			),
+			'additionalProperties' => false,
+		);
+	}
+
+	/**
+	 * Sanitize a raw mapping configuration array.
+	 *
+	 * Whitelists known fields, sanitizes slugs and term names, and drops
+	 * malformed entries. Returns a structure safe to persist and apply.
+	 *
+	 * @param array<string, mixed> $mapping Raw mapping data.
+	 * @return array<string, mixed> Sanitized mapping.
+	 */
+	public static function sanitize( array $mapping ): array {
+		$clean = array();
+
+		if ( isset( $mapping['post_type'] ) && is_string( $mapping['post_type'] ) && '' !== $mapping['post_type'] ) {
+			$clean['post_type'] = sanitize_key( $mapping['post_type'] );
+		}
+
+		if ( isset( $mapping['post_status'] )
+			&& is_string( $mapping['post_status'] )
+			&& in_array( $mapping['post_status'], self::ALLOWED_STATUSES, true )
+		) {
+			$clean['post_status'] = $mapping['post_status'];
+		}
+
+		if ( isset( $mapping['post_type_mappings'] ) && is_array( $mapping['post_type_mappings'] ) ) {
+			$clean['post_type_mappings'] = array();
+
+			foreach ( $mapping['post_type_mappings'] as $entry ) {
+				if ( ! is_array( $entry )
+					|| empty( $entry['source_content_type'] )
+					|| empty( $entry['destination_post_type'] )
+					|| ! is_string( $entry['source_content_type'] )
+					|| ! is_string( $entry['destination_post_type'] )
+				) {
+					continue;
+				}
+
+				$clean['post_type_mappings'][] = array(
+					'source_content_type'   => sanitize_key( $entry['source_content_type'] ),
+					'destination_post_type' => sanitize_key( $entry['destination_post_type'] ),
+				);
+			}
+		}
+
+		if ( isset( $mapping['taxonomy_mappings'] ) && is_array( $mapping['taxonomy_mappings'] ) ) {
+			$clean['taxonomy_mappings'] = array();
+
+			foreach ( $mapping['taxonomy_mappings'] as $entry ) {
+				if ( ! is_array( $entry )
+					|| empty( $entry['source_signal'] )
+					|| empty( $entry['destination_taxonomy'] )
+					|| ! is_string( $entry['source_signal'] )
+					|| ! is_string( $entry['destination_taxonomy'] )
+				) {
+					continue;
+				}
+
+				$terms = array();
+
+				if ( isset( $entry['destination_terms'] ) && is_array( $entry['destination_terms'] ) ) {
+					foreach ( $entry['destination_terms'] as $term ) {
+						if ( is_string( $term ) && '' !== trim( $term ) ) {
+							$terms[] = sanitize_text_field( $term );
+						}
+					}
+				}
+
+				$clean['taxonomy_mappings'][] = array(
+					'source_signal'        => sanitize_text_field( $entry['source_signal'] ),
+					'destination_taxonomy' => sanitize_key( $entry['destination_taxonomy'] ),
+					'destination_terms'    => $terms,
+				);
+			}
+		}
+
+		return $clean;
+	}
+
+	/**
+	 * Get the option key for an adapter's saved mapping.
+	 *
+	 * @param string $adapter_id Adapter ID.
+	 * @return string
+	 */
+	public static function get_option_key( string $adapter_id ): string {
+		return self::OPTION_PREFIX . $adapter_id;
+	}
+}

--- a/src/api.js
+++ b/src/api.js
@@ -73,20 +73,66 @@ export function fetchManifest( sourceId ) {
 }
 
 /**
+ * Fetch AI mapping suggestions for a connected source.
+ *
+ * @param {string} sourceId The adapter ID.
+ * @return {Promise<Object>} Suggestions, analysis, and site schema.
+ */
+export function fetchMappingSuggestions( sourceId ) {
+	return apiFetch( {
+		path: `${ API_BASE }/sources/${ sourceId }/mapping-suggestions`,
+	} );
+}
+
+/**
+ * Fetch the saved mapping configuration for a source.
+ *
+ * @param {string} sourceId The adapter ID.
+ * @return {Promise<Object>} Saved mapping (mapping is null when none saved).
+ */
+export function fetchSavedMapping( sourceId ) {
+	return apiFetch( {
+		path: `${ API_BASE }/sources/${ sourceId }/mappings`,
+	} );
+}
+
+/**
+ * Save a mapping configuration for reuse.
+ *
+ * @param {string} sourceId The adapter ID.
+ * @param {Object} mapping  Mapping configuration to persist.
+ * @return {Promise<Object>} Saved mapping data.
+ */
+export function saveMapping( sourceId, mapping ) {
+	return apiFetch( {
+		path: `${ API_BASE }/sources/${ sourceId }/mappings`,
+		method: 'POST',
+		data: { mapping },
+	} );
+}
+
+/**
  * Start a new import batch.
  *
  * @param {string}   sourceAdapter The adapter ID.
  * @param {string[]} itemIds       Manifest item IDs to import.
+ * @param {?Object}  mapping       Optional mapping configuration to apply.
  * @return {Promise<Object>} Created batch data.
  */
-export function startImport( sourceAdapter, itemIds ) {
+export function startImport( sourceAdapter, itemIds, mapping = null ) {
+	const data = {
+		source_adapter: sourceAdapter,
+		item_ids: itemIds,
+	};
+
+	if ( mapping ) {
+		data.mapping = mapping;
+	}
+
 	return apiFetch( {
 		path: `${ API_BASE }/imports`,
 		method: 'POST',
-		data: {
-			source_adapter: sourceAdapter,
-			item_ids: itemIds,
-		},
+		data,
 	} );
 }
 

--- a/src/components/MappingConfiguration.js
+++ b/src/components/MappingConfiguration.js
@@ -1,0 +1,570 @@
+/**
+ * Mapping configuration component for the import wizard.
+ *
+ * Fetches AI mapping suggestions for the selected source, pre-fills the
+ * controls from a previously saved mapping when one exists, and lets the
+ * user accept, modify, or reject the suggested mapping before importing.
+ */
+
+import { useState, useEffect, useMemo } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	Notice,
+	SelectControl,
+	Spinner,
+	TextControl,
+} from '@wordpress/components';
+import {
+	fetchMappingSuggestions,
+	fetchSavedMapping,
+	saveMapping,
+} from '../api';
+
+const DEFAULT_POST_TYPE = 'post';
+const DEFAULT_POST_STATUS = 'draft';
+
+const POST_STATUS_OPTIONS = [
+	{ label: __( 'Draft', 'ai-importer' ), value: 'draft' },
+	{ label: __( 'Published', 'ai-importer' ), value: 'publish' },
+	{ label: __( 'Pending Review', 'ai-importer' ), value: 'pending' },
+	{ label: __( 'Private', 'ai-importer' ), value: 'private' },
+];
+
+/**
+ * Build editable mapping state from a saved mapping or AI suggestions.
+ *
+ * @param {?Object} saved       Saved mapping config (or null).
+ * @param {?Object} suggestions AI suggestions (or null).
+ * @return {Object} Editable mapping state.
+ */
+function buildInitialMapping( saved, suggestions ) {
+	if ( saved ) {
+		return {
+			postType: saved.post_type || DEFAULT_POST_TYPE,
+			postStatus: saved.post_status || DEFAULT_POST_STATUS,
+			postTypeMappings: ( saved.post_type_mappings || [] ).map(
+				( entry ) => ( { ...entry, reasoning: '' } )
+			),
+			taxonomyMappings: ( saved.taxonomy_mappings || [] ).map(
+				( entry ) => ( {
+					...entry,
+					destination_terms: entry.destination_terms || [],
+					reasoning: '',
+				} )
+			),
+		};
+	}
+
+	if ( suggestions ) {
+		return {
+			postType: DEFAULT_POST_TYPE,
+			postStatus: DEFAULT_POST_STATUS,
+			postTypeMappings: ( suggestions.post_type_mappings || [] ).map(
+				( entry ) => ( {
+					source_content_type: entry.source_content_type,
+					destination_post_type: entry.destination_post_type,
+					reasoning: entry.reasoning || '',
+				} )
+			),
+			taxonomyMappings: ( suggestions.taxonomy_mappings || [] ).map(
+				( entry ) => ( {
+					source_signal: entry.source_signal,
+					destination_taxonomy: entry.destination_taxonomy,
+					destination_terms: entry.destination_terms || [],
+					reasoning: entry.reasoning || '',
+				} )
+			),
+		};
+	}
+
+	return {
+		postType: DEFAULT_POST_TYPE,
+		postStatus: DEFAULT_POST_STATUS,
+		postTypeMappings: [],
+		taxonomyMappings: [],
+	};
+}
+
+/**
+ * Convert editable mapping state to the REST mapping payload.
+ *
+ * Rows without a destination are treated as rejected and dropped.
+ *
+ * @param {Object} mapping Editable mapping state.
+ * @return {Object} Mapping payload for the REST API.
+ */
+function toMappingPayload( mapping ) {
+	return {
+		post_type: mapping.postType || DEFAULT_POST_TYPE,
+		post_status: mapping.postStatus || DEFAULT_POST_STATUS,
+		post_type_mappings: mapping.postTypeMappings
+			.filter( ( entry ) => entry.destination_post_type )
+			.map( ( entry ) => ( {
+				source_content_type: entry.source_content_type,
+				destination_post_type: entry.destination_post_type,
+			} ) ),
+		taxonomy_mappings: mapping.taxonomyMappings
+			.filter( ( entry ) => entry.destination_taxonomy )
+			.map( ( entry ) => ( {
+				source_signal: entry.source_signal,
+				destination_taxonomy: entry.destination_taxonomy,
+				destination_terms: entry.destination_terms,
+			} ) ),
+	};
+}
+
+/**
+ * MappingConfiguration component.
+ *
+ * @param {Object}   props               Component props.
+ * @param {string}   props.sourceId      The selected source adapter ID.
+ * @param {Function} props.onStartImport Called with the mapping payload (or null for defaults).
+ * @param {Function} props.onBack        Called to go back to the review step.
+ * @param {boolean}  props.isLoading     Whether the import is starting.
+ * @return {JSX.Element} The component.
+ */
+export default function MappingConfiguration( {
+	sourceId,
+	onStartImport,
+	onBack,
+	isLoading,
+} ) {
+	const [ loading, setLoading ] = useState( true );
+	const [ loadError, setLoadError ] = useState( null );
+	const [ suggestions, setSuggestions ] = useState( null );
+	const [ siteSchema, setSiteSchema ] = useState( null );
+	const [ usedSavedMapping, setUsedSavedMapping ] = useState( false );
+	const [ mapping, setMapping ] = useState( () =>
+		buildInitialMapping( null, null )
+	);
+	const [ saving, setSaving ] = useState( false );
+	const [ saveNotice, setSaveNotice ] = useState( null );
+
+	useEffect( () => {
+		let cancelled = false;
+
+		const load = async () => {
+			setLoading( true );
+			setLoadError( null );
+
+			let saved = null;
+			try {
+				const savedResponse = await fetchSavedMapping( sourceId );
+				saved = savedResponse?.mapping || null;
+			} catch ( err ) {
+				// A missing saved mapping is not fatal; suggestions still load.
+				saved = null;
+			}
+
+			try {
+				const data = await fetchMappingSuggestions( sourceId );
+				if ( cancelled ) {
+					return;
+				}
+				setSuggestions( data.suggestions );
+				setSiteSchema( data.site_schema );
+				setMapping( buildInitialMapping( saved, data.suggestions ) );
+				setUsedSavedMapping( !! saved );
+			} catch ( err ) {
+				if ( cancelled ) {
+					return;
+				}
+				setLoadError(
+					err.message ||
+						__(
+							'Failed to fetch mapping suggestions.',
+							'ai-importer'
+						)
+				);
+			} finally {
+				if ( ! cancelled ) {
+					setLoading( false );
+				}
+			}
+		};
+
+		load();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [ sourceId ] );
+
+	const postTypeOptions = useMemo( () => {
+		const types = siteSchema?.post_types || [];
+		const options = types.map( ( type ) => ( {
+			label: type.name,
+			value: type.slug,
+		} ) );
+
+		if ( ! options.some( ( option ) => option.value === 'post' ) ) {
+			options.unshift( {
+				label: __( 'Posts', 'ai-importer' ),
+				value: 'post',
+			} );
+		}
+
+		return options;
+	}, [ siteSchema ] );
+
+	const taxonomyOptions = useMemo( () => {
+		const taxonomies = siteSchema?.taxonomies || [];
+		return [
+			{ label: __( 'Do not map', 'ai-importer' ), value: '' },
+			...taxonomies.map( ( taxonomy ) => ( {
+				label: taxonomy.name,
+				value: taxonomy.slug,
+			} ) ),
+		];
+	}, [ siteSchema ] );
+
+	const handleReset = () => {
+		setMapping( {
+			postType: DEFAULT_POST_TYPE,
+			postStatus: DEFAULT_POST_STATUS,
+			postTypeMappings: [],
+			taxonomyMappings: [],
+		} );
+		setSaveNotice( null );
+	};
+
+	const handleAcceptSuggestions = () => {
+		setMapping( buildInitialMapping( null, suggestions ) );
+		setSaveNotice( null );
+	};
+
+	const handleSaveMapping = async () => {
+		setSaving( true );
+		setSaveNotice( null );
+		try {
+			await saveMapping( sourceId, toMappingPayload( mapping ) );
+			setSaveNotice( {
+				status: 'success',
+				message: __(
+					'Mapping saved. It will be pre-filled next time you import from this source.',
+					'ai-importer'
+				),
+			} );
+		} catch ( err ) {
+			setSaveNotice( {
+				status: 'error',
+				message:
+					err.message ||
+					__( 'Failed to save mapping.', 'ai-importer' ),
+			} );
+		} finally {
+			setSaving( false );
+		}
+	};
+
+	const updatePostTypeMapping = ( index, destination ) => {
+		setMapping( ( current ) => ( {
+			...current,
+			postTypeMappings: current.postTypeMappings.map( ( entry, i ) =>
+				i === index
+					? { ...entry, destination_post_type: destination }
+					: entry
+			),
+		} ) );
+	};
+
+	const updateTaxonomyMapping = ( index, changes ) => {
+		setMapping( ( current ) => ( {
+			...current,
+			taxonomyMappings: current.taxonomyMappings.map( ( entry, i ) =>
+				i === index ? { ...entry, ...changes } : entry
+			),
+		} ) );
+	};
+
+	if ( loading ) {
+		return (
+			<Card>
+				<CardBody>
+					<div className="ai-importer-mapping__loading">
+						<Spinner />
+						<p>
+							{ __(
+								'Analyzing your content and site structure…',
+								'ai-importer'
+							) }
+						</p>
+					</div>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	if ( loadError ) {
+		return (
+			<Card>
+				<CardBody>
+					<Notice status="error" isDismissible={ false }>
+						{ loadError }
+					</Notice>
+					<p>
+						{ __(
+							'You can continue without AI suggestions. Imported items will be created as draft posts.',
+							'ai-importer'
+						) }
+					</p>
+					<div className="ai-importer-mapping__actions">
+						<Button variant="secondary" onClick={ onBack }>
+							{ __( 'Back', 'ai-importer' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ () => onStartImport( null ) }
+							isBusy={ isLoading }
+							disabled={ isLoading }
+						>
+							{ __( 'Continue with defaults', 'ai-importer' ) }
+						</Button>
+					</div>
+				</CardBody>
+			</Card>
+		);
+	}
+
+	return (
+		<div className="ai-importer-mapping">
+			{ usedSavedMapping && (
+				<Notice status="info" isDismissible={ false }>
+					{ __(
+						'A previously saved mapping for this source was loaded. Review or adjust it below.',
+						'ai-importer'
+					) }
+				</Notice>
+			) }
+
+			{ saveNotice && (
+				<Notice
+					status={ saveNotice.status }
+					isDismissible
+					onDismiss={ () => setSaveNotice( null ) }
+				>
+					{ saveNotice.message }
+				</Notice>
+			) }
+
+			<Card>
+				<CardHeader>
+					<h2>{ __( 'Configure Mapping', 'ai-importer' ) }</h2>
+				</CardHeader>
+				<CardBody>
+					{ suggestions?.summary && (
+						<div className="ai-importer-mapping__summary">
+							<h3>
+								{ __( 'AI Recommendation', 'ai-importer' ) }
+							</h3>
+							<p>{ suggestions.summary }</p>
+						</div>
+					) }
+
+					<div className="ai-importer-mapping__controls">
+						<SelectControl
+							label={ __( 'Default post type', 'ai-importer' ) }
+							value={ mapping.postType }
+							options={ postTypeOptions }
+							onChange={ ( value ) =>
+								setMapping( ( current ) => ( {
+									...current,
+									postType: value,
+								} ) )
+							}
+							help={ __(
+								'Used for content without a more specific mapping below.',
+								'ai-importer'
+							) }
+							__nextHasNoMarginBottom
+						/>
+
+						<SelectControl
+							label={ __( 'Post status', 'ai-importer' ) }
+							value={ mapping.postStatus }
+							options={ POST_STATUS_OPTIONS }
+							onChange={ ( value ) =>
+								setMapping( ( current ) => ( {
+									...current,
+									postStatus: value,
+								} ) )
+							}
+							help={ __(
+								'Status assigned to every imported item.',
+								'ai-importer'
+							) }
+							__nextHasNoMarginBottom
+						/>
+					</div>
+
+					{ mapping.postTypeMappings.length > 0 && (
+						<div className="ai-importer-mapping__section">
+							<h3>
+								{ __( 'Content type mappings', 'ai-importer' ) }
+							</h3>
+							{ mapping.postTypeMappings.map(
+								( entry, index ) => (
+									<div
+										key={ `${ entry.source_content_type }-${ index }` }
+										className="ai-importer-mapping__row"
+									>
+										<SelectControl
+											label={ sprintf(
+												/* translators: %s: source content type slug. */
+												__(
+													'"%s" content becomes',
+													'ai-importer'
+												),
+												entry.source_content_type
+											) }
+											value={
+												entry.destination_post_type
+											}
+											options={ postTypeOptions }
+											onChange={ ( value ) =>
+												updatePostTypeMapping(
+													index,
+													value
+												)
+											}
+											__nextHasNoMarginBottom
+										/>
+										{ entry.reasoning && (
+											<p className="ai-importer-mapping__reasoning">
+												{ entry.reasoning }
+											</p>
+										) }
+									</div>
+								)
+							) }
+						</div>
+					) }
+
+					{ mapping.taxonomyMappings.length > 0 && (
+						<div className="ai-importer-mapping__section">
+							<h3>
+								{ __( 'Taxonomy mappings', 'ai-importer' ) }
+							</h3>
+							{ mapping.taxonomyMappings.map(
+								( entry, index ) => (
+									<div
+										key={ `${ entry.source_signal }-${ index }` }
+										className="ai-importer-mapping__row"
+									>
+										<SelectControl
+											label={ sprintf(
+												/* translators: %s: source signal, e.g. hashtags. */
+												__(
+													'Map "%s" to',
+													'ai-importer'
+												),
+												entry.source_signal
+											) }
+											value={ entry.destination_taxonomy }
+											options={ taxonomyOptions }
+											onChange={ ( value ) =>
+												updateTaxonomyMapping( index, {
+													destination_taxonomy: value,
+												} )
+											}
+											__nextHasNoMarginBottom
+										/>
+										{ entry.source_signal === 'hashtags' ? (
+											<p className="ai-importer-mapping__help">
+												{ __(
+													'Each item’s hashtags become terms in the selected taxonomy.',
+													'ai-importer'
+												) }
+											</p>
+										) : (
+											<TextControl
+												label={ __(
+													'Terms (comma-separated)',
+													'ai-importer'
+												) }
+												value={ entry.destination_terms.join(
+													', '
+												) }
+												onChange={ ( value ) =>
+													updateTaxonomyMapping(
+														index,
+														{
+															destination_terms:
+																value
+																	.split(
+																		','
+																	)
+																	.map(
+																		(
+																			term
+																		) =>
+																			term.trim()
+																	)
+																	.filter(
+																		Boolean
+																	),
+														}
+													)
+												}
+												__nextHasNoMarginBottom
+											/>
+										) }
+										{ entry.reasoning && (
+											<p className="ai-importer-mapping__reasoning">
+												{ entry.reasoning }
+											</p>
+										) }
+									</div>
+								)
+							) }
+						</div>
+					) }
+
+					<div className="ai-importer-mapping__secondary-actions">
+						<Button
+							variant="tertiary"
+							onClick={ handleAcceptSuggestions }
+							disabled={ ! suggestions }
+						>
+							{ __( 'Reset to AI suggestions', 'ai-importer' ) }
+						</Button>
+						<Button variant="tertiary" onClick={ handleReset }>
+							{ __(
+								'Reject suggestions (use defaults)',
+								'ai-importer'
+							) }
+						</Button>
+						<Button
+							variant="secondary"
+							onClick={ handleSaveMapping }
+							isBusy={ saving }
+							disabled={ saving }
+						>
+							{ __( 'Save mapping for reuse', 'ai-importer' ) }
+						</Button>
+					</div>
+
+					<div className="ai-importer-mapping__actions">
+						<Button variant="secondary" onClick={ onBack }>
+							{ __( 'Back', 'ai-importer' ) }
+						</Button>
+						<Button
+							variant="primary"
+							onClick={ () =>
+								onStartImport( toMappingPayload( mapping ) )
+							}
+							isBusy={ isLoading }
+							disabled={ isLoading }
+						>
+							{ __( 'Start Import', 'ai-importer' ) }
+						</Button>
+					</div>
+				</CardBody>
+			</Card>
+		</div>
+	);
+}

--- a/src/pages/ImportWizard.js
+++ b/src/pages/ImportWizard.js
@@ -14,6 +14,7 @@ import {
 import SourceCard from '../components/SourceCard';
 import FileUpload from '../components/FileUpload';
 import ContentReview from '../components/ContentReview';
+import MappingConfiguration from '../components/MappingConfiguration';
 import ImportProgress from '../components/ImportProgress';
 import {
 	fetchSources,
@@ -25,6 +26,7 @@ import {
 const STEP_SELECT_SOURCE = 'select-source';
 const STEP_CONNECT = 'connect';
 const STEP_REVIEW = 'review';
+const STEP_MAPPING = 'mapping';
 const STEP_IMPORT = 'import';
 const STEP_COMPLETE = 'complete';
 
@@ -38,6 +40,7 @@ export default function ImportWizard() {
 	const [ sources, setSources ] = useState( [] );
 	const [ selectedSource, setSelectedSource ] = useState( null );
 	const [ manifest, setManifest ] = useState( null );
+	const [ pendingItemIds, setPendingItemIds ] = useState( [] );
 	const [ batchId, setBatchId ] = useState( null );
 	const [ completedData, setCompletedData ] = useState( null );
 	const [ error, setError ] = useState( null );
@@ -107,11 +110,21 @@ export default function ImportWizard() {
 		}
 	};
 
-	const handleStartImport = async ( itemIds ) => {
+	const handleReviewContinue = ( itemIds ) => {
+		setPendingItemIds( itemIds );
+		setError( null );
+		setStep( STEP_MAPPING );
+	};
+
+	const handleStartImport = async ( mapping ) => {
 		setLoading( true );
 		setError( null );
 		try {
-			const batch = await startImport( selectedSource.id, itemIds );
+			const batch = await startImport(
+				selectedSource.id,
+				pendingItemIds,
+				mapping
+			);
 			setBatchId( batch.id );
 			setStep( STEP_IMPORT );
 		} catch ( err ) {
@@ -132,6 +145,7 @@ export default function ImportWizard() {
 		setStep( STEP_SELECT_SOURCE );
 		setSelectedSource( null );
 		setManifest( null );
+		setPendingItemIds( [] );
 		setBatchId( null );
 		setCompletedData( null );
 		setError( null );
@@ -163,6 +177,10 @@ export default function ImportWizard() {
 						{
 							key: STEP_REVIEW,
 							label: __( 'Review', 'ai-importer' ),
+						},
+						{
+							key: STEP_MAPPING,
+							label: __( 'Configure Mapping', 'ai-importer' ),
 						},
 						{
 							key: STEP_IMPORT,
@@ -236,7 +254,7 @@ export default function ImportWizard() {
 				<>
 					<ContentReview
 						manifest={ manifest }
-						onImport={ handleStartImport }
+						onImport={ handleReviewContinue }
 						isLoading={ loading }
 					/>
 					<Button
@@ -247,6 +265,15 @@ export default function ImportWizard() {
 						{ __( 'Start over', 'ai-importer' ) }
 					</Button>
 				</>
+			) }
+
+			{ step === STEP_MAPPING && selectedSource && (
+				<MappingConfiguration
+					sourceId={ selectedSource.id }
+					onStartImport={ handleStartImport }
+					onBack={ () => setStep( STEP_REVIEW ) }
+					isLoading={ loading }
+				/>
 			) }
 
 			{ step === STEP_IMPORT && batchId && (

--- a/src/style.scss
+++ b/src/style.scss
@@ -392,6 +392,75 @@
 	}
 }
 
+// Mapping configuration
+.ai-importer-mapping {
+
+	&__loading {
+		display: flex;
+		align-items: center;
+		gap: 8px;
+		padding: 16px 0;
+	}
+
+	&__summary {
+		margin-bottom: 16px;
+		padding: 12px;
+		background: #f0f6fc;
+		border-left: 4px solid #007cba;
+
+		h3 {
+			margin: 0 0 4px;
+		}
+
+		p {
+			margin: 0;
+		}
+	}
+
+	&__controls {
+		display: grid;
+		grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+		gap: 16px;
+		margin-bottom: 16px;
+	}
+
+	&__section {
+		margin-bottom: 16px;
+		padding-top: 16px;
+		border-top: 1px solid #e0e0e0;
+
+		h3 {
+			margin: 0 0 8px;
+		}
+	}
+
+	&__row {
+		margin-bottom: 12px;
+	}
+
+	&__reasoning,
+	&__help {
+		margin: 4px 0 0;
+		font-size: 12px;
+		font-style: italic;
+		color: #757575;
+	}
+
+	&__secondary-actions {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 8px;
+		margin-bottom: 16px;
+	}
+
+	&__actions {
+		display: flex;
+		gap: 8px;
+		padding-top: 16px;
+		border-top: 1px solid #e0e0e0;
+	}
+}
+
 // Status badges (shared)
 .ai-importer-status {
 	display: inline-block;

--- a/tests/Unit/Processor/ContentCreatorTest.php
+++ b/tests/Unit/Processor/ContentCreatorTest.php
@@ -219,6 +219,172 @@ class ContentCreatorTest extends TestCase {
 	}
 
 	/**
+	 * Test posts default to draft status and the post post type.
+	 *
+	 * @return void
+	 */
+	public function test_defaults_without_mapping(): void {
+		$captured = $this->capture_insert_args();
+
+		$this->creator->create( $this->make_item(), 'batch-abc' );
+
+		$this->assertSame( 'post', $captured['args']['post_type'] );
+		$this->assertSame( 'draft', $captured['args']['post_status'] );
+	}
+
+	/**
+	 * Test the mapping's default post type and status are applied.
+	 *
+	 * @return void
+	 */
+	public function test_mapping_post_type_and_status_applied(): void {
+		$captured = $this->capture_insert_args();
+
+		$this->creator->create(
+			$this->make_item(),
+			'batch-abc',
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			)
+		);
+
+		$this->assertSame( 'page', $captured['args']['post_type'] );
+		$this->assertSame( 'publish', $captured['args']['post_status'] );
+	}
+
+	/**
+	 * Test a per-content-type override wins over the mapping default.
+	 *
+	 * @return void
+	 */
+	public function test_mapping_post_type_override_per_content_type(): void {
+		$captured = $this->capture_insert_args();
+
+		$this->creator->create(
+			$this->make_item(),
+			'batch-abc',
+			array(
+				'post_type'          => 'page',
+				'post_type_mappings' => array(
+					array(
+						'source_content_type'   => 'thread',
+						'destination_post_type' => 'story',
+					),
+					array(
+						'source_content_type'   => ContentType::POST->value,
+						'destination_post_type' => 'note',
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 'note', $captured['args']['post_type'] );
+	}
+
+	/**
+	 * Test a hashtags taxonomy mapping routes tags to the destination taxonomy.
+	 *
+	 * @return void
+	 */
+	public function test_mapping_routes_hashtags_to_taxonomy(): void {
+		$set_terms = array();
+		$set_tags  = false;
+
+		Functions\when( 'wp_set_object_terms' )->alias(
+			function ( $post_id, $terms, $taxonomy ) use ( &$set_terms ) {
+				$set_terms[ $taxonomy ] = $terms;
+				return array();
+			}
+		);
+		Functions\when( 'wp_set_post_tags' )->alias(
+			function () use ( &$set_tags ) {
+				$set_tags = true;
+				return true;
+			}
+		);
+
+		$item = $this->make_item( array( 'tags' => array( 'wordpress', 'ai' ) ) );
+
+		$this->creator->create(
+			$item,
+			'batch-abc',
+			array(
+				'taxonomy_mappings' => array(
+					array(
+						'source_signal'        => 'hashtags',
+						'destination_taxonomy' => 'topic',
+						'destination_terms'    => array(),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'wordpress', 'ai' ), $set_terms['topic'] );
+		$this->assertFalse( $set_tags, 'Default hashtag handling should be skipped when mapped.' );
+	}
+
+	/**
+	 * Test fixed destination terms are assigned for non-hashtag signals.
+	 *
+	 * @return void
+	 */
+	public function test_mapping_assigns_fixed_destination_terms(): void {
+		$set_terms = array();
+		$set_tags  = false;
+
+		Functions\when( 'wp_set_object_terms' )->alias(
+			function ( $post_id, $terms, $taxonomy ) use ( &$set_terms ) {
+				$set_terms[ $taxonomy ] = $terms;
+				return array();
+			}
+		);
+		Functions\when( 'wp_set_post_tags' )->alias(
+			function () use ( &$set_tags ) {
+				$set_tags = true;
+				return true;
+			}
+		);
+
+		$item = $this->make_item( array( 'tags' => array( 'wordpress' ) ) );
+
+		$this->creator->create(
+			$item,
+			'batch-abc',
+			array(
+				'taxonomy_mappings' => array(
+					array(
+						'source_signal'        => 'suggested_categories',
+						'destination_taxonomy' => 'category',
+						'destination_terms'    => array( 'Notes', 'Updates' ),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( array( 'Notes', 'Updates' ), $set_terms['category'] );
+		$this->assertTrue( $set_tags, 'Default hashtag handling should still run when hashtags are not mapped.' );
+	}
+
+	/**
+	 * Capture the args passed to wp_insert_post.
+	 *
+	 * @return \ArrayObject<string, mixed> Container populated with 'args' on insert.
+	 */
+	private function capture_insert_args(): \ArrayObject {
+		$captured = new \ArrayObject( array( 'args' => array() ) );
+
+		Functions\when( 'wp_insert_post' )->alias(
+			function ( $args ) use ( $captured ) {
+				$captured['args'] = $args;
+				return 42;
+			}
+		);
+
+		return $captured;
+	}
+
+	/**
 	 * Create a test NormalizedItem.
 	 *
 	 * @param array<string, mixed> $overrides Field overrides.

--- a/tests/Unit/Processor/ImportProcessorTest.php
+++ b/tests/Unit/Processor/ImportProcessorTest.php
@@ -446,6 +446,75 @@ class ImportProcessorTest extends TestCase {
 	}
 
 	/**
+	 * Test process_batch passes the batch mapping to the content creator.
+	 *
+	 * @return void
+	 */
+	public function test_process_batch_passes_mapping_to_creator(): void {
+		$this->register_mock_adapter();
+
+		$mapping = array(
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		);
+
+		$creator = Mockery::mock( ContentCreator::class );
+		$creator->shouldReceive( 'create' )
+			->once()
+			->with( Mockery::type( NormalizedItem::class ), 'batch-1', $mapping )
+			->andReturn( 100 );
+
+		$media_handler = Mockery::mock( MediaHandler::class );
+		$media_handler->shouldReceive( 'process' )->andReturn( array() );
+
+		$normalizer = $this->create_mock_normalizer();
+
+		Filters\expectApplied( 'ai_importer_normalizers' )
+			->andReturn( array( 'twitter' => $normalizer ) );
+
+		$this->store_batch( 'batch-1', 'processing', array( 'item-1' ) );
+		$this->options['ai_importer_batch_batch-1']['mapping'] = $mapping;
+
+		$processor = new ImportProcessor( $creator, $media_handler );
+		$processor->process_batch( 'batch-1' );
+
+		$batch = $this->options['ai_importer_batch_batch-1'];
+		$this->assertSame( 'completed', $batch['state'] );
+		$this->assertSame( 1, $batch['processed'] );
+	}
+
+	/**
+	 * Test process_batch passes an empty mapping when the batch has none.
+	 *
+	 * @return void
+	 */
+	public function test_process_batch_defaults_to_empty_mapping(): void {
+		$this->register_mock_adapter();
+
+		$creator = Mockery::mock( ContentCreator::class );
+		$creator->shouldReceive( 'create' )
+			->once()
+			->with( Mockery::type( NormalizedItem::class ), 'batch-1', array() )
+			->andReturn( 100 );
+
+		$media_handler = Mockery::mock( MediaHandler::class );
+		$media_handler->shouldReceive( 'process' )->andReturn( array() );
+
+		$normalizer = $this->create_mock_normalizer();
+
+		Filters\expectApplied( 'ai_importer_normalizers' )
+			->andReturn( array( 'twitter' => $normalizer ) );
+
+		$this->store_batch( 'batch-1', 'processing', array( 'item-1' ) );
+
+		$processor = new ImportProcessor( $creator, $media_handler );
+		$processor->process_batch( 'batch-1' );
+
+		$batch = $this->options['ai_importer_batch_batch-1'];
+		$this->assertSame( 1, $batch['processed'] );
+	}
+
+	/**
 	 * Create a mock normalizer that returns a NormalizedItem.
 	 *
 	 * @return ContentNormalizer&\Mockery\MockInterface

--- a/tests/Unit/REST/ImportsControllerTest.php
+++ b/tests/Unit/REST/ImportsControllerTest.php
@@ -106,6 +106,76 @@ class ImportsControllerTest extends TestCase {
 	}
 
 	/**
+	 * Test create_item stores a sanitized mapping on the batch.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_stores_sanitized_mapping(): void {
+		$this->register_mock_adapter( 'twitter', true );
+
+		Functions\when( 'sanitize_key' )->alias(
+			function ( $key ) {
+				return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->alias(
+			function ( $value ) {
+				return trim( (string) $value );
+			}
+		);
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/imports' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'item_ids'       => array( 'tweet-1' ),
+				'mapping'        => array(
+					'post_type'     => 'page',
+					'post_status'   => 'publish',
+					'unknown_field' => 'evil',
+				),
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $result );
+
+		$batch = $this->options['ai_importer_batch_test-uuid-1234'];
+
+		$this->assertSame(
+			array(
+				'post_type'   => 'page',
+				'post_status' => 'publish',
+			),
+			$batch['mapping']
+		);
+	}
+
+	/**
+	 * Test create_item defaults to an empty mapping when none is supplied.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_defaults_to_empty_mapping(): void {
+		$this->register_mock_adapter( 'twitter', true );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/imports' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'item_ids'       => array( 'tweet-1' ),
+			)
+		);
+
+		$this->controller->create_item( $request );
+
+		$batch = $this->options['ai_importer_batch_test-uuid-1234'];
+
+		$this->assertSame( array(), $batch['mapping'] );
+	}
+
+	/**
 	 * Test create_item rejects unknown adapter.
 	 *
 	 * @return void

--- a/tests/Unit/REST/SourcesControllerTest.php
+++ b/tests/Unit/REST/SourcesControllerTest.php
@@ -531,6 +531,170 @@ class SourcesControllerTest extends TestCase {
 	}
 
 	/**
+	 * Test get_mapping returns null when no mapping is saved.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_returns_null_when_none_saved(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		Functions\when( 'get_option' )->justReturn( null );
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mappings' );
+		$request['id'] = 'twitter';
+
+		$response = $this->controller->get_mapping( $request );
+		$result   = $response->get_data();
+
+		$this->assertSame( 'twitter', $result['source_id'] );
+		$this->assertNull( $result['mapping'] );
+	}
+
+	/**
+	 * Test get_mapping returns the saved mapping from the expected option.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_returns_saved_mapping(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$mapping = array(
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		);
+
+		Functions\when( 'get_option' )->alias(
+			function ( $key, $default = false ) use ( $mapping ) {
+				return 'ai_importer_mappings_twitter' === $key ? $mapping : $default;
+			}
+		);
+
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/twitter/mappings' );
+		$request['id'] = 'twitter';
+
+		$response = $this->controller->get_mapping( $request );
+		$result   = $response->get_data();
+
+		$this->assertSame( $mapping, $result['mapping'] );
+	}
+
+	/**
+	 * Test get_mapping returns 404 for an unknown source.
+	 *
+	 * @return void
+	 */
+	public function test_get_mapping_source_not_found(): void {
+		$request       = new WP_REST_Request( 'GET', '/ai-importer/v1/sources/unknown/mappings' );
+		$request['id'] = 'unknown';
+
+		$result = $this->controller->get_mapping( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'source_not_found', $result->get_error_codes() );
+	}
+
+	/**
+	 * Test save_mapping persists a sanitized mapping in the adapter option.
+	 *
+	 * @return void
+	 */
+	public function test_save_mapping_persists_sanitized_mapping(): void {
+		$this->register_mock_adapter( 'twitter' );
+		$this->stub_sanitizers();
+
+		$saved = array();
+
+		Functions\when( 'update_option' )->alias(
+			function ( $key, $value, $autoload = null ) use ( &$saved ) {
+				$saved[ $key ] = $value;
+				return true;
+			}
+		);
+
+		$request       = new WP_REST_Request( 'POST', '/ai-importer/v1/sources/twitter/mappings' );
+		$request['id'] = 'twitter';
+		$request->set_body_params(
+			array(
+				'mapping' => array(
+					'post_type'     => 'page',
+					'post_status'   => 'publish',
+					'unknown_field' => 'evil',
+				),
+			)
+		);
+
+		$response = $this->controller->save_mapping( $request );
+		$result   = $response->get_data();
+
+		$expected = array(
+			'post_type'   => 'page',
+			'post_status' => 'publish',
+		);
+
+		$this->assertSame( $expected, $result['mapping'] );
+		$this->assertSame( $expected, $saved['ai_importer_mappings_twitter'] );
+	}
+
+	/**
+	 * Test save_mapping rejects a mapping with no valid fields.
+	 *
+	 * @return void
+	 */
+	public function test_save_mapping_rejects_invalid_mapping(): void {
+		$this->register_mock_adapter( 'twitter' );
+		$this->stub_sanitizers();
+
+		$request       = new WP_REST_Request( 'POST', '/ai-importer/v1/sources/twitter/mappings' );
+		$request['id'] = 'twitter';
+		$request->set_body_params(
+			array(
+				'mapping' => array( 'post_status' => 'trash' ),
+			)
+		);
+
+		$result = $this->controller->save_mapping( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'invalid_mapping', $result->get_error_codes() );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * Test save_mapping rejects a missing mapping parameter.
+	 *
+	 * @return void
+	 */
+	public function test_save_mapping_requires_mapping(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$request       = new WP_REST_Request( 'POST', '/ai-importer/v1/sources/twitter/mappings' );
+		$request['id'] = 'twitter';
+
+		$result = $this->controller->save_mapping( $request );
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertContains( 'invalid_mapping', $result->get_error_codes() );
+	}
+
+	/**
+	 * Stub sanitization functions used by MappingConfig::sanitize().
+	 *
+	 * @return void
+	 */
+	private function stub_sanitizers(): void {
+		Functions\when( 'sanitize_key' )->alias(
+			function ( $key ) {
+				return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->alias(
+			function ( $value ) {
+				return trim( (string) $value );
+			}
+		);
+	}
+
+	/**
 	 * Test permissions check denies unauthorized users.
 	 *
 	 * @return void

--- a/tests/Unit/Schema/MappingConfigTest.php
+++ b/tests/Unit/Schema/MappingConfigTest.php
@@ -1,0 +1,157 @@
+<?php
+/**
+ * MappingConfig tests.
+ *
+ * @package AI_Importer\Tests\Unit\Schema
+ */
+
+namespace AI_Importer\Tests\Unit\Schema;
+
+use AI_Importer\Schema\MappingConfig;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+
+/**
+ * Tests for the MappingConfig class.
+ */
+class MappingConfigTest extends TestCase {
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		Functions\when( 'sanitize_key' )->alias(
+			function ( $key ) {
+				return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $key ) );
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->alias(
+			function ( $value ) {
+				return trim( strip_tags( (string) $value ) ); // phpcs:ignore WordPress.WP.AlternativeFunctions.strip_tags_strip_tags -- Test stub.
+			}
+		);
+	}
+
+	/**
+	 * Test the schema describes the expected top-level properties.
+	 *
+	 * @return void
+	 */
+	public function test_schema_shape(): void {
+		$schema = MappingConfig::get_schema();
+
+		$this->assertSame( 'object', $schema['type'] );
+		$this->assertArrayHasKey( 'post_type', $schema['properties'] );
+		$this->assertArrayHasKey( 'post_status', $schema['properties'] );
+		$this->assertArrayHasKey( 'post_type_mappings', $schema['properties'] );
+		$this->assertArrayHasKey( 'taxonomy_mappings', $schema['properties'] );
+		$this->assertFalse( $schema['additionalProperties'] );
+		$this->assertSame( MappingConfig::ALLOWED_STATUSES, $schema['properties']['post_status']['enum'] );
+	}
+
+	/**
+	 * Test sanitize keeps a complete valid mapping.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_keeps_valid_mapping(): void {
+		$mapping = array(
+			'post_type'          => 'page',
+			'post_status'        => 'publish',
+			'post_type_mappings' => array(
+				array(
+					'source_content_type'   => 'thread',
+					'destination_post_type' => 'page',
+				),
+			),
+			'taxonomy_mappings'  => array(
+				array(
+					'source_signal'        => 'hashtags',
+					'destination_taxonomy' => 'post_tag',
+					'destination_terms'    => array(),
+				),
+				array(
+					'source_signal'        => 'suggested_categories',
+					'destination_taxonomy' => 'category',
+					'destination_terms'    => array( 'Notes', 'Updates' ),
+				),
+			),
+		);
+
+		$this->assertSame( $mapping, MappingConfig::sanitize( $mapping ) );
+	}
+
+	/**
+	 * Test sanitize strips unknown fields and malformed entries.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_strips_unknown_and_malformed(): void {
+		$result = MappingConfig::sanitize(
+			array(
+				'post_type'          => 'page',
+				'unknown_field'      => 'evil',
+				'post_type_mappings' => array(
+					array( 'source_content_type' => 'thread' ), // Missing destination.
+					'not-an-array',
+				),
+				'taxonomy_mappings'  => array(
+					array( 'destination_taxonomy' => 'category' ), // Missing signal.
+				),
+			)
+		);
+
+		$this->assertSame( 'page', $result['post_type'] );
+		$this->assertArrayNotHasKey( 'unknown_field', $result );
+		$this->assertSame( array(), $result['post_type_mappings'] );
+		$this->assertSame( array(), $result['taxonomy_mappings'] );
+	}
+
+	/**
+	 * Test sanitize rejects post statuses outside the allowed list.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_rejects_invalid_status(): void {
+		$result = MappingConfig::sanitize( array( 'post_status' => 'trash' ) );
+
+		$this->assertArrayNotHasKey( 'post_status', $result );
+	}
+
+	/**
+	 * Test sanitize cleans slugs and term names.
+	 *
+	 * @return void
+	 */
+	public function test_sanitize_cleans_values(): void {
+		$result = MappingConfig::sanitize(
+			array(
+				'post_type'         => 'My Page!',
+				'taxonomy_mappings' => array(
+					array(
+						'source_signal'        => 'suggested_categories',
+						'destination_taxonomy' => 'Category!',
+						'destination_terms'    => array( '  Notes  ', '', 123 ),
+					),
+				),
+			)
+		);
+
+		$this->assertSame( 'mypage', $result['post_type'] );
+		$this->assertSame( 'category', $result['taxonomy_mappings'][0]['destination_taxonomy'] );
+		$this->assertSame( array( 'Notes' ), $result['taxonomy_mappings'][0]['destination_terms'] );
+	}
+
+	/**
+	 * Test the option key uses the documented prefix.
+	 *
+	 * @return void
+	 */
+	public function test_option_key(): void {
+		$this->assertSame( 'ai_importer_mappings_twitter', MappingConfig::get_option_key( 'twitter' ) );
+	}
+}


### PR DESCRIPTION
## Description

Adds a full mapping configuration flow to the import wizard, letting users review and adjust AI mapping suggestions before importing, and persisting mappings for reuse.

Part of #11 (https://github.com/adamsilverstein/ai-importer/issues/11) and #14 (https://github.com/adamsilverstein/ai-importer/issues/14).

### Backend

- **`MappingConfig`** (`includes/Schema/MappingConfig.php`): shared definition of the mapping shape - default post type, post status (enum-validated), per-content-type post type overrides, and taxonomy mappings. Provides a JSON schema for REST validation and a sanitizer that whitelists fields and cleans slugs/term names.
- **Saved mappings endpoints (F3.5)**: `GET`/`POST /sources/{id}/mappings` read and persist a mapping in the `ai_importer_mappings_{adapter_id}` option, guarded by `manage_options` and schema-validated args.
- **Mapping application on import**: `POST /imports` accepts an optional `mapping` object that is sanitized and stored on the batch. `ImportProcessor` forwards it to `ContentCreator`, which resolves the destination post type (per-content-type overrides win over the mapping default), post status, and taxonomy mappings. A `hashtags` taxonomy mapping routes item tags to the chosen taxonomy; otherwise default hashtag-to-tag behavior is preserved. Without a mapping, behavior is unchanged (`post`/`draft`/tags).

### Frontend (F3.4, F6.3)

- New **"Configure Mapping" step** in the import wizard between content review and import.
- Fetches `GET /sources/{id}/mapping-suggestions` (spinner while loading) and renders the AI summary plus per-mapping reasoning.
- Editable controls built from the destination site schema: default post type, post status, per-content-type post type selects, and taxonomy mapping selects with comma-separated terms.
- Accept as-is ("Reset to AI suggestions"), modify in place, or reject ("use defaults": `post`, `draft`, no taxonomy mapping).
- "Save mapping for reuse" persists via the mappings endpoint; on entry a previously saved mapping is loaded and pre-filled with an info notice.
- On suggestion failure, an error notice offers "Continue with defaults".
- The chosen mapping is sent with `POST /imports`.

Reconciled with the incremental import duplicate detection from #94: the mapping is applied inside the new skip/update flow, and batches keep both `mapping` and the `skipped`/`update_existing` fields.

## Testing

- `composer run lint` (PHPCS, WordPress Coding Standards): clean
- `./vendor/bin/phpunit`: 536 tests, 1213 assertions passing (new coverage for `MappingConfig` schema/sanitization, the saved mappings routes, the `mapping` param on `POST /imports`, mapping pass-through in `ImportProcessor`, and post type/status/taxonomy application in `ContentCreator`)
- `npm run lint` (JS + CSS): clean
- `npm run build`: compiles successfully
