### PR TITLE
Add scheduled imports for connected sources (F10.3)

### DIFF
--- a/includes/Plugin.php
+++ b/includes/Plugin.php
@@ -22,9 +22,11 @@ use AI_Importer\AI\MetaDescriptionGenerator;
 use AI_Importer\AI\TitleGenerator;
 use AI_Importer\Processor\ContentCleaner;
 use AI_Importer\Processor\ImportProcessor;
+use AI_Importer\Processor\ImportScheduler;
 use AI_Importer\Processor\ItemEnhancer;
 use AI_Importer\Processor\MediaHandler;
 use AI_Importer\REST\ImportsController;
+use AI_Importer\REST\SchedulesController;
 use AI_Importer\REST\SourcesController;
 
 /**
@@ -106,6 +108,11 @@ class Plugin {
 		$processor     = new ImportProcessor( null, $media_handler, $this->build_item_enhancer( $ai_service ) );
 		$processor->init();
 
+		// Initialize scheduled imports (F10.3). Registers the recurring
+		// Action Scheduler hook so scheduled runs fire on all requests.
+		$scheduler = new ImportScheduler();
+		$scheduler->init();
+
 		// Initialize admin.
 		if ( is_admin() ) {
 			$this->admin = new Admin();
@@ -127,6 +134,9 @@ class Plugin {
 
 		$imports_controller = new ImportsController();
 		$imports_controller->register_routes();
+
+		$schedules_controller = new SchedulesController();
+		$schedules_controller->register_routes();
 	}
 
 	/**

--- a/includes/Processor/ImportScheduler.php
+++ b/includes/Processor/ImportScheduler.php
@@ -1,0 +1,475 @@
+<?php
+/**
+ * Scheduled import runner.
+ *
+ * @package AI_Importer
+ */
+
+namespace AI_Importer\Processor;
+
+use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Schema\MappingConfig;
+
+/**
+ * Manages recurring "scheduled imports" (PRD F10.3).
+ *
+ * A schedule records that a connected source should be polled automatically
+ * on a recurring interval. When the recurring Action Scheduler hook fires for
+ * a schedule, the scheduler fetches the source's manifest, builds the list of
+ * item IDs, and creates an import batch reusing the standard batch-creation
+ * path with update_existing=true. Because update_existing is true, the
+ * incremental duplicate detection (F10.2) means a scheduled run only imports
+ * NEW content while leaving previously imported posts untouched.
+ *
+ * Schedules are stored in the ai_importer_schedules option as a list of:
+ *   - id              string  Unique schedule UUID.
+ *   - source_adapter  string  Adapter ID to import from.
+ *   - interval        string  One of hourly|daily|weekly.
+ *   - update_existing bool    Whether duplicate posts should be updated.
+ *   - enabled         bool    Whether the schedule is active.
+ *   - last_run        ?string ISO 8601 timestamp of the last run, or null.
+ *   - next_run        ?int    Unix timestamp of the next scheduled run, or null.
+ */
+class ImportScheduler {
+
+	/**
+	 * Option key holding the list of schedules.
+	 */
+	public const OPTION_KEY = 'ai_importer_schedules';
+
+	/**
+	 * Action Scheduler hook fired for each scheduled run.
+	 */
+	public const HOOK_NAME = 'ai_importer_run_scheduled_import';
+
+	/**
+	 * Action Scheduler group name.
+	 */
+	private const AS_GROUP = 'ai-importer';
+
+	/**
+	 * Supported recurrence intervals mapped to seconds.
+	 *
+	 * @var array<string, int>
+	 */
+	public const INTERVALS = array(
+		'hourly' => HOUR_IN_SECONDS,
+		'daily'  => DAY_IN_SECONDS,
+		'weekly' => WEEK_IN_SECONDS,
+	);
+
+	/**
+	 * Register WordPress hooks.
+	 *
+	 * @return void
+	 */
+	public function init(): void {
+		add_action( self::HOOK_NAME, array( $this, 'run_schedule' ) );
+	}
+
+	/**
+	 * Get all stored schedules.
+	 *
+	 * @return array<int, array<string, mixed>> List of schedule records.
+	 */
+	public function get_schedules(): array {
+		$schedules = get_option( self::OPTION_KEY, array() );
+
+		return is_array( $schedules ) ? array_values( $schedules ) : array();
+	}
+
+	/**
+	 * Get a single schedule by ID.
+	 *
+	 * @param string $schedule_id Schedule ID.
+	 * @return array<string, mixed>|null The schedule, or null when not found.
+	 */
+	public function get_schedule( string $schedule_id ): ?array {
+		foreach ( $this->get_schedules() as $schedule ) {
+			if ( isset( $schedule['id'] ) && $schedule['id'] === $schedule_id ) {
+				return $schedule;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Create or update a schedule and (re)register its recurring action.
+	 *
+	 * When an existing ID is supplied the matching schedule is replaced;
+	 * otherwise a new schedule is created with a generated UUID. The recurring
+	 * Action Scheduler action is always re-registered to reflect the latest
+	 * interval and enabled state.
+	 *
+	 * @param array<string, mixed> $data {
+	 *     Schedule data.
+	 *
+	 *     @type string $id              Optional. Existing schedule ID to update.
+	 *     @type string $source_adapter  Adapter ID.
+	 *     @type string $interval        One of hourly|daily|weekly.
+	 *     @type bool   $update_existing Whether to update duplicate posts.
+	 *     @type bool   $enabled         Whether the schedule is active.
+	 * }
+	 * @return array<string, mixed> The saved schedule record.
+	 */
+	public function save_schedule( array $data ): array {
+		$schedules = $this->get_schedules();
+
+		$id       = isset( $data['id'] ) && is_string( $data['id'] ) && '' !== $data['id'] ? $data['id'] : '';
+		$interval = isset( $data['interval'] ) && isset( self::INTERVALS[ $data['interval'] ] )
+			? $data['interval']
+			: 'daily';
+
+		$schedule = array(
+			'id'              => '' !== $id ? $id : wp_generate_uuid4(),
+			'source_adapter'  => isset( $data['source_adapter'] ) ? sanitize_text_field( (string) $data['source_adapter'] ) : '',
+			'interval'        => $interval,
+			'update_existing' => ! empty( $data['update_existing'] ),
+			'enabled'         => ! isset( $data['enabled'] ) || ! empty( $data['enabled'] ),
+			'last_run'        => null,
+			'next_run'        => null,
+		);
+
+		// Preserve last_run from any existing record being updated.
+		$found = false;
+
+		foreach ( $schedules as $index => $existing ) {
+			if ( isset( $existing['id'] ) && $existing['id'] === $schedule['id'] ) {
+				$schedule['last_run'] = $existing['last_run'] ?? null;
+				$schedules[ $index ]  = $schedule;
+				$found                = true;
+				break;
+			}
+		}
+
+		if ( ! $found ) {
+			$schedules[] = $schedule;
+		}
+
+		// (Re)register the recurring action and capture the next run time.
+		$schedule['next_run'] = $this->register_action( $schedule );
+
+		// Persist the next_run on the stored record too.
+		foreach ( $schedules as $index => $existing ) {
+			if ( $existing['id'] === $schedule['id'] ) {
+				$schedules[ $index ] = $schedule;
+				break;
+			}
+		}
+
+		$this->persist( $schedules );
+
+		return $schedule;
+	}
+
+	/**
+	 * Delete a schedule and unschedule its recurring action.
+	 *
+	 * @param string $schedule_id Schedule ID.
+	 * @return bool True when a schedule was removed.
+	 */
+	public function delete_schedule( string $schedule_id ): bool {
+		$schedules = $this->get_schedules();
+		$remaining = array();
+		$removed   = false;
+
+		foreach ( $schedules as $schedule ) {
+			if ( isset( $schedule['id'] ) && $schedule['id'] === $schedule_id ) {
+				$this->unregister_action( $schedule_id );
+				$removed = true;
+				continue;
+			}
+
+			$remaining[] = $schedule;
+		}
+
+		if ( $removed ) {
+			$this->persist( $remaining );
+		}
+
+		return $removed;
+	}
+
+	/**
+	 * Action Scheduler callback: run a scheduled import for a source.
+	 *
+	 * Resolves the schedule, validates the source is connected, fetches the
+	 * manifest, and creates an import batch reusing the existing batch-creation
+	 * path. Records last_run/next_run. Disconnected or unauthenticated sources
+	 * are logged and skipped rather than crashing the scheduler. Overlapping
+	 * runs are skipped when a batch for the same source is still processing.
+	 *
+	 * @param string $schedule_id Schedule ID passed as the action argument.
+	 * @return void
+	 */
+	public function run_schedule( string $schedule_id ): void {
+		$schedule = $this->get_schedule( $schedule_id );
+
+		if ( null === $schedule ) {
+			$this->log( sprintf( 'Scheduled import skipped: schedule "%s" not found.', $schedule_id ) );
+			return;
+		}
+
+		// Always record the run timestamp and refresh the next run estimate.
+		$this->record_run( $schedule_id );
+
+		if ( empty( $schedule['enabled'] ) ) {
+			$this->log( sprintf( 'Scheduled import skipped: schedule "%s" is disabled.', $schedule_id ) );
+			return;
+		}
+
+		$source_adapter = (string) ( $schedule['source_adapter'] ?? '' );
+		$adapter        = AdapterRegistry::get_instance()->get( $source_adapter );
+
+		if ( null === $adapter ) {
+			$this->log( sprintf( 'Scheduled import skipped: source adapter "%s" not found.', $source_adapter ) );
+			return;
+		}
+
+		if ( ! $adapter->is_authenticated() ) {
+			$this->log( sprintf( 'Scheduled import skipped: source adapter "%s" is not connected.', $source_adapter ) );
+			return;
+		}
+
+		// Guard against overlapping runs for the same source.
+		if ( $this->has_active_batch( $source_adapter ) ) {
+			$this->log( sprintf( 'Scheduled import skipped: an import for "%s" is already processing.', $source_adapter ) );
+			return;
+		}
+
+		try {
+			$manifest = $adapter->fetch_manifest();
+		} catch ( \Throwable $e ) {
+			$this->log(
+				sprintf(
+					'Scheduled import for "%s" failed to fetch manifest: %s',
+					$source_adapter,
+					$e->getMessage()
+				)
+			);
+			return;
+		}
+
+		$item_ids = array_keys( $manifest->get_items() );
+
+		if ( empty( $item_ids ) ) {
+			$this->log( sprintf( 'Scheduled import for "%s" found no items.', $source_adapter ) );
+			return;
+		}
+
+		$this->create_batch( $schedule, $item_ids );
+	}
+
+	/**
+	 * Create an import batch for a scheduled run.
+	 *
+	 * Mirrors ImportsController::create_item so scheduled and manual imports
+	 * share the same batch shape, index, and lifecycle hook. update_existing
+	 * is forced on so duplicate detection only imports new content. The
+	 * source's saved mapping is reused when present.
+	 *
+	 * @param array<string, mixed> $schedule Schedule record.
+	 * @param array<int, string>   $item_ids Item IDs to import.
+	 * @return string The created batch ID.
+	 */
+	private function create_batch( array $schedule, array $item_ids ): string {
+		$source_adapter = (string) $schedule['source_adapter'];
+		$batch_id       = wp_generate_uuid4();
+		$now            = gmdate( 'c' );
+
+		$saved_mapping = get_option( MappingConfig::get_option_key( $source_adapter ), array() );
+		$mapping       = is_array( $saved_mapping ) ? MappingConfig::sanitize( $saved_mapping ) : array();
+
+		$batch = array(
+			'id'              => $batch_id,
+			'source_adapter'  => $source_adapter,
+			'state'           => 'processing',
+			'item_ids'        => array_values( $item_ids ),
+			'mapping'         => $mapping,
+			'total'           => count( $item_ids ),
+			'processed'       => 0,
+			'failed'          => 0,
+			'skipped'         => 0,
+			// Scheduled runs always update/skip existing content so only new
+			// items are imported via duplicate detection (F10.2).
+			'update_existing' => true,
+			'errors'          => array(),
+			'created_at'      => $now,
+			'started_at'      => null,
+			'completed_at'    => null,
+			'imported_ids'    => array(),
+			// Mark provenance so history can distinguish scheduled runs.
+			'scheduled'       => true,
+			'schedule_id'     => (string) $schedule['id'],
+		);
+
+		update_option( 'ai_importer_batch_' . $batch_id, $batch, false );
+
+		$index   = get_option( 'ai_importer_batch_index', array() );
+		$index   = is_array( $index ) ? $index : array();
+		$index[] = $batch_id;
+		update_option( 'ai_importer_batch_index', $index, false );
+
+		/**
+		 * Fires when a new import batch is created.
+		 *
+		 * The import processor hooks into this action to begin processing.
+		 *
+		 * @param string               $batch_id The batch UUID.
+		 * @param array<string, mixed> $batch    The batch data.
+		 */
+		do_action( 'ai_importer_batch_created', $batch_id, $batch );
+
+		$this->log(
+			sprintf(
+				'Scheduled import for "%s" created batch %s with %d item(s).',
+				$source_adapter,
+				$batch_id,
+				count( $item_ids )
+			)
+		);
+
+		return $batch_id;
+	}
+
+	/**
+	 * Determine whether a source already has a processing batch.
+	 *
+	 * @param string $source_adapter Adapter ID.
+	 * @return bool True when an active (processing/paused) batch exists.
+	 */
+	private function has_active_batch( string $source_adapter ): bool {
+		$index = get_option( 'ai_importer_batch_index', array() );
+
+		if ( ! is_array( $index ) ) {
+			return false;
+		}
+
+		foreach ( $index as $batch_id ) {
+			$batch = get_option( 'ai_importer_batch_' . $batch_id, false );
+
+			if ( ! is_array( $batch ) ) {
+				continue;
+			}
+
+			if ( ( $batch['source_adapter'] ?? '' ) !== $source_adapter ) {
+				continue;
+			}
+
+			if ( in_array( $batch['state'] ?? '', array( 'processing', 'paused' ), true ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Record a run: set last_run and refresh next_run for a schedule.
+	 *
+	 * @param string $schedule_id Schedule ID.
+	 * @return void
+	 */
+	private function record_run( string $schedule_id ): void {
+		$schedules = $this->get_schedules();
+
+		foreach ( $schedules as $index => $schedule ) {
+			if ( ( $schedule['id'] ?? '' ) !== $schedule_id ) {
+				continue;
+			}
+
+			$schedules[ $index ]['last_run'] = gmdate( 'c' );
+			$schedules[ $index ]['next_run'] = $this->next_scheduled( $schedule_id );
+			break;
+		}
+
+		$this->persist( $schedules );
+	}
+
+	/**
+	 * (Re)register the recurring Action Scheduler action for a schedule.
+	 *
+	 * Any existing action for the schedule is cleared first so interval
+	 * changes take effect. Disabled schedules are unscheduled and not
+	 * re-registered.
+	 *
+	 * @param array<string, mixed> $schedule Schedule record.
+	 * @return int|null Next run Unix timestamp, or null when not scheduled.
+	 */
+	private function register_action( array $schedule ): ?int {
+		$schedule_id = (string) $schedule['id'];
+
+		$this->unregister_action( $schedule_id );
+
+		if ( empty( $schedule['enabled'] ) ) {
+			return null;
+		}
+
+		$interval_seconds = self::INTERVALS[ $schedule['interval'] ] ?? self::INTERVALS['daily'];
+		$start            = time() + $interval_seconds;
+
+		if ( function_exists( 'as_schedule_recurring_action' ) ) {
+			as_schedule_recurring_action(
+				$start,
+				$interval_seconds,
+				self::HOOK_NAME,
+				array( $schedule_id ),
+				self::AS_GROUP
+			);
+		}
+
+		return $this->next_scheduled( $schedule_id ) ?? $start;
+	}
+
+	/**
+	 * Unschedule the recurring action for a schedule.
+	 *
+	 * @param string $schedule_id Schedule ID.
+	 * @return void
+	 */
+	private function unregister_action( string $schedule_id ): void {
+		if ( function_exists( 'as_unschedule_action' ) ) {
+			as_unschedule_action( self::HOOK_NAME, array( $schedule_id ), self::AS_GROUP );
+		}
+	}
+
+	/**
+	 * Get the next scheduled run timestamp for a schedule.
+	 *
+	 * @param string $schedule_id Schedule ID.
+	 * @return int|null Unix timestamp, or null when nothing is scheduled.
+	 */
+	private function next_scheduled( string $schedule_id ): ?int {
+		if ( ! function_exists( 'as_next_scheduled_action' ) ) {
+			return null;
+		}
+
+		$next = as_next_scheduled_action( self::HOOK_NAME, array( $schedule_id ), self::AS_GROUP );
+
+		return is_int( $next ) ? $next : null;
+	}
+
+	/**
+	 * Persist the schedule list to the database.
+	 *
+	 * @param array<int, array<string, mixed>> $schedules Schedule list.
+	 * @return void
+	 */
+	private function persist( array $schedules ): void {
+		update_option( self::OPTION_KEY, array_values( $schedules ), false );
+	}
+
+	/**
+	 * Log a scheduler message when debugging is enabled.
+	 *
+	 * @param string $message Message to log.
+	 * @return void
+	 */
+	private function log( string $message ): void {
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			error_log( 'AI Importer [scheduler]: ' . $message );
+		}
+	}
+}

--- a/includes/REST/SchedulesController.php
+++ b/includes/REST/SchedulesController.php
@@ -1,0 +1,265 @@
+<?php
+/**
+ * REST controller for scheduled imports.
+ *
+ * @package AI_Importer
+ */
+
+namespace AI_Importer\REST;
+
+use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Processor\ImportScheduler;
+use WP_Error;
+use WP_REST_Controller;
+use WP_REST_Request;
+use WP_REST_Response;
+use WP_REST_Server;
+
+/**
+ * Handles REST API endpoints for managing scheduled imports (PRD F10.3).
+ *
+ * Schedules are stored via ImportScheduler in the ai_importer_schedules option.
+ *
+ * Endpoints:
+ *   GET    /schedules            - List schedules
+ *   POST   /schedules            - Create or update a schedule
+ *   DELETE /schedules/{id}       - Delete a schedule
+ */
+class SchedulesController extends WP_REST_Controller {
+
+	/**
+	 * Route namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'ai-importer/v1';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'schedules';
+
+	/**
+	 * Scheduler service.
+	 *
+	 * @var ImportScheduler
+	 */
+	private ImportScheduler $scheduler;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param ImportScheduler|null $scheduler Optional scheduler instance.
+	 */
+	public function __construct( ?ImportScheduler $scheduler = null ) {
+		$this->scheduler = $scheduler ?? new ImportScheduler();
+	}
+
+	/**
+	 * Register REST routes.
+	 *
+	 * @return void
+	 */
+	public function register_routes(): void {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+				),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'id'              => array(
+							'type'              => 'string',
+							'required'          => false,
+							'sanitize_callback' => 'sanitize_text_field',
+							'description'       => __( 'Existing schedule ID to update.', 'ai-importer' ),
+						),
+						'source_adapter'  => array(
+							'type'              => 'string',
+							'required'          => true,
+							'sanitize_callback' => 'sanitize_text_field',
+							'description'       => __( 'Adapter ID to import from.', 'ai-importer' ),
+						),
+						'interval'        => array(
+							'type'        => 'string',
+							'required'    => true,
+							'enum'        => array_keys( ImportScheduler::INTERVALS ),
+							'description' => __( 'Recurrence interval.', 'ai-importer' ),
+						),
+						'update_existing' => array(
+							'type'              => 'boolean',
+							'default'           => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						),
+						'enabled'         => array(
+							'type'              => 'boolean',
+							'default'           => true,
+							'sanitize_callback' => 'rest_sanitize_boolean',
+						),
+					),
+				),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[a-f0-9-]+)',
+			array(
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'permissions_check' ),
+					'args'                => array(
+						'id' => array(
+							'required'          => true,
+							'type'              => 'string',
+							'sanitize_callback' => 'sanitize_text_field',
+						),
+					),
+				),
+			)
+		);
+	}
+
+	/**
+	 * Check if the current user can manage schedules.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return bool|WP_Error
+	 */
+	public function permissions_check( $request ): bool|WP_Error {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return new WP_Error(
+				'rest_forbidden',
+				__( 'You do not have permission to manage scheduled imports.', 'ai-importer' ),
+				array( 'status' => 403 )
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * List all schedules.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function get_items( $request ): WP_REST_Response {
+		$schedules = array_map(
+			array( $this, 'serialize_schedule' ),
+			$this->scheduler->get_schedules()
+		);
+
+		return rest_ensure_response( array_values( $schedules ) );
+	}
+
+	/**
+	 * Create or update a schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function create_item( $request ): WP_REST_Response|WP_Error {
+		$source_adapter = (string) $request->get_param( 'source_adapter' );
+		$interval       = (string) $request->get_param( 'interval' );
+
+		// Validate the adapter exists.
+		$adapter = AdapterRegistry::get_instance()->get( $source_adapter );
+
+		if ( null === $adapter ) {
+			return new WP_Error(
+				'invalid_source',
+				__( 'Source adapter not found.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		if ( ! isset( ImportScheduler::INTERVALS[ $interval ] ) ) {
+			return new WP_Error(
+				'invalid_interval',
+				__( 'Invalid recurrence interval.', 'ai-importer' ),
+				array( 'status' => 400 )
+			);
+		}
+
+		$id = $request->get_param( 'id' );
+
+		// When updating, the schedule must already exist.
+		if ( is_string( $id ) && '' !== $id && null === $this->scheduler->get_schedule( $id ) ) {
+			return new WP_Error(
+				'schedule_not_found',
+				__( 'Scheduled import not found.', 'ai-importer' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$schedule = $this->scheduler->save_schedule(
+			array(
+				'id'              => is_string( $id ) ? $id : '',
+				'source_adapter'  => $source_adapter,
+				'interval'        => $interval,
+				'update_existing' => (bool) $request->get_param( 'update_existing' ),
+				'enabled'         => (bool) $request->get_param( 'enabled' ),
+			)
+		);
+
+		return new WP_REST_Response( $this->serialize_schedule( $schedule ), 201 );
+	}
+
+	/**
+	 * Delete a schedule.
+	 *
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response|WP_Error
+	 */
+	public function delete_item( $request ): WP_REST_Response|WP_Error {
+		$id = (string) $request['id'];
+
+		if ( null === $this->scheduler->get_schedule( $id ) ) {
+			return new WP_Error(
+				'schedule_not_found',
+				__( 'Scheduled import not found.', 'ai-importer' ),
+				array( 'status' => 404 )
+			);
+		}
+
+		$this->scheduler->delete_schedule( $id );
+
+		return rest_ensure_response(
+			array(
+				'deleted' => true,
+				'id'      => $id,
+			)
+		);
+	}
+
+	/**
+	 * Serialize a schedule for API responses.
+	 *
+	 * @param array<string, mixed> $schedule Raw schedule record.
+	 * @return array<string, mixed>
+	 */
+	private function serialize_schedule( array $schedule ): array {
+		$next_run = $schedule['next_run'] ?? null;
+
+		return array(
+			'id'              => (string) ( $schedule['id'] ?? '' ),
+			'source_adapter'  => (string) ( $schedule['source_adapter'] ?? '' ),
+			'interval'        => (string) ( $schedule['interval'] ?? 'daily' ),
+			'update_existing' => ! empty( $schedule['update_existing'] ),
+			'enabled'         => ! empty( $schedule['enabled'] ),
+			'last_run'        => $schedule['last_run'] ?? null,
+			'next_run'        => is_int( $next_run ) ? gmdate( 'c', $next_run ) : null,
+		);
+	}
+}

--- a/src/api.js
+++ b/src/api.js
@@ -203,3 +203,61 @@ export function rollbackImport( batchId ) {
 		method: 'DELETE',
 	} );
 }
+
+/**
+ * Fetch all scheduled imports.
+ *
+ * @return {Promise<Array>} List of schedules.
+ */
+export function fetchSchedules() {
+	return apiFetch( { path: `${ API_BASE }/schedules` } );
+}
+
+/**
+ * Create or update a scheduled import.
+ *
+ * @param {Object}  schedule                Schedule data.
+ * @param {?string} schedule.id             Existing schedule ID to update.
+ * @param {string}  schedule.sourceAdapter  Adapter ID to import from.
+ * @param {string}  schedule.interval       Recurrence (hourly|daily|weekly).
+ * @param {boolean} schedule.updateExisting Update duplicate posts.
+ * @param {boolean} schedule.enabled        Whether the schedule is active.
+ * @return {Promise<Object>} Saved schedule data.
+ */
+export function saveSchedule( {
+	id = null,
+	sourceAdapter,
+	interval,
+	updateExisting = true,
+	enabled = true,
+} ) {
+	const data = {
+		source_adapter: sourceAdapter,
+		interval,
+		update_existing: updateExisting,
+		enabled,
+	};
+
+	if ( id ) {
+		data.id = id;
+	}
+
+	return apiFetch( {
+		path: `${ API_BASE }/schedules`,
+		method: 'POST',
+		data,
+	} );
+}
+
+/**
+ * Delete a scheduled import.
+ *
+ * @param {string} scheduleId The schedule ID.
+ * @return {Promise<Object>} Deletion result.
+ */
+export function deleteSchedule( scheduleId ) {
+	return apiFetch( {
+		path: `${ API_BASE }/schedules/${ scheduleId }`,
+		method: 'DELETE',
+	} );
+}

--- a/src/components/ScheduledImports.js
+++ b/src/components/ScheduledImports.js
@@ -1,0 +1,343 @@
+/**
+ * Scheduled imports management (PRD F10.3).
+ *
+ * Lists configured schedules for connected sources and provides a form to
+ * add new schedules, toggle them on/off, and delete them.
+ */
+
+import { useState, useEffect, useCallback } from '@wordpress/element';
+import { __ } from '@wordpress/i18n';
+import {
+	Button,
+	Card,
+	CardBody,
+	CardHeader,
+	CheckboxControl,
+	Flex,
+	FlexItem,
+	Notice,
+	SelectControl,
+	Spinner,
+	ToggleControl,
+} from '@wordpress/components';
+import {
+	fetchSources,
+	fetchSchedules,
+	saveSchedule,
+	deleteSchedule,
+} from '../api';
+
+const INTERVAL_OPTIONS = [
+	{ label: __( 'Hourly', 'ai-importer' ), value: 'hourly' },
+	{ label: __( 'Daily', 'ai-importer' ), value: 'daily' },
+	{ label: __( 'Weekly', 'ai-importer' ), value: 'weekly' },
+];
+
+/**
+ * Format an ISO date string for display.
+ *
+ * @param {?string} dateStr ISO 8601 date string.
+ * @return {string} Localized date or a dash.
+ */
+function formatDate( dateStr ) {
+	if ( ! dateStr ) {
+		return '—';
+	}
+	return new Date( dateStr ).toLocaleString();
+}
+
+/**
+ * Scheduled imports component.
+ *
+ * @return {JSX.Element} The component.
+ */
+export default function ScheduledImports() {
+	const [ schedules, setSchedules ] = useState( [] );
+	const [ sources, setSources ] = useState( [] );
+	const [ loading, setLoading ] = useState( true );
+	const [ saving, setSaving ] = useState( false );
+	const [ error, setError ] = useState( null );
+
+	const [ sourceAdapter, setSourceAdapter ] = useState( '' );
+	const [ interval, setInterval ] = useState( 'daily' );
+	const [ updateExisting, setUpdateExisting ] = useState( true );
+
+	const connectedSources = sources.filter(
+		( source ) => source.is_authenticated
+	);
+
+	const reloadSchedules = useCallback( async () => {
+		const data = await fetchSchedules();
+		setSchedules( data );
+	}, [] );
+
+	useEffect( () => {
+		const load = async () => {
+			try {
+				const [ sourceData, scheduleData ] = await Promise.all( [
+					fetchSources(),
+					fetchSchedules(),
+				] );
+				const sourceList = Array.isArray( sourceData )
+					? sourceData
+					: Object.values( sourceData || {} );
+				setSources( sourceList );
+				setSchedules( scheduleData );
+
+				const firstConnected = sourceList.find(
+					( source ) => source.is_authenticated
+				);
+				if ( firstConnected ) {
+					setSourceAdapter( firstConnected.id );
+				}
+			} catch ( err ) {
+				setError( err.message );
+			} finally {
+				setLoading( false );
+			}
+		};
+		load();
+	}, [] );
+
+	const sourceLabel = useCallback(
+		( id ) => {
+			const match = sources.find( ( source ) => source.id === id );
+			return match ? match.name : id;
+		},
+		[ sources ]
+	);
+
+	const handleAdd = async () => {
+		if ( ! sourceAdapter ) {
+			return;
+		}
+		setSaving( true );
+		setError( null );
+		try {
+			await saveSchedule( {
+				sourceAdapter,
+				interval,
+				updateExisting,
+				enabled: true,
+			} );
+			await reloadSchedules();
+		} catch ( err ) {
+			setError( err.message );
+		} finally {
+			setSaving( false );
+		}
+	};
+
+	const handleToggle = async ( schedule, enabled ) => {
+		setError( null );
+		try {
+			await saveSchedule( {
+				id: schedule.id,
+				sourceAdapter: schedule.source_adapter,
+				interval: schedule.interval,
+				updateExisting: schedule.update_existing,
+				enabled,
+			} );
+			await reloadSchedules();
+		} catch ( err ) {
+			setError( err.message );
+		}
+	};
+
+	const handleDelete = async ( schedule ) => {
+		setError( null );
+		try {
+			await deleteSchedule( schedule.id );
+			await reloadSchedules();
+		} catch ( err ) {
+			setError( err.message );
+		}
+	};
+
+	return (
+		<Card>
+			<CardHeader>
+				<h2>{ __( 'Scheduled Imports', 'ai-importer' ) }</h2>
+			</CardHeader>
+			<CardBody>
+				<p>
+					{ __(
+						'Automatically import new content from connected sources on a recurring schedule. Scheduled runs only import items that have not been imported before.',
+						'ai-importer'
+					) }
+				</p>
+
+				{ error && (
+					<Notice
+						status="error"
+						isDismissible
+						onDismiss={ () => setError( null ) }
+					>
+						{ error }
+					</Notice>
+				) }
+
+				{ loading ? (
+					<Spinner />
+				) : (
+					<>
+						{ schedules.length > 0 ? (
+							<table className="ai-importer-schedules__table wp-list-table widefat striped">
+								<thead>
+									<tr>
+										<th scope="col">
+											{ __( 'Source', 'ai-importer' ) }
+										</th>
+										<th scope="col">
+											{ __( 'Interval', 'ai-importer' ) }
+										</th>
+										<th scope="col">
+											{ __( 'Enabled', 'ai-importer' ) }
+										</th>
+										<th scope="col">
+											{ __( 'Last run', 'ai-importer' ) }
+										</th>
+										<th scope="col">
+											{ __( 'Next run', 'ai-importer' ) }
+										</th>
+										<th scope="col">
+											{ __( 'Actions', 'ai-importer' ) }
+										</th>
+									</tr>
+								</thead>
+								<tbody>
+									{ schedules.map( ( schedule ) => (
+										<tr key={ schedule.id }>
+											<td>
+												{ sourceLabel(
+													schedule.source_adapter
+												) }
+											</td>
+											<td>{ schedule.interval }</td>
+											<td>
+												<ToggleControl
+													__nextHasNoMarginBottom
+													label={ __(
+														'Enabled',
+														'ai-importer'
+													) }
+													hideLabelFromVision
+													checked={ schedule.enabled }
+													onChange={ ( value ) =>
+														handleToggle(
+															schedule,
+															value
+														)
+													}
+												/>
+											</td>
+											<td>
+												{ formatDate(
+													schedule.last_run
+												) }
+											</td>
+											<td>
+												{ formatDate(
+													schedule.next_run
+												) }
+											</td>
+											<td>
+												<Button
+													variant="link"
+													isDestructive
+													onClick={ () =>
+														handleDelete( schedule )
+													}
+												>
+													{ __(
+														'Delete',
+														'ai-importer'
+													) }
+												</Button>
+											</td>
+										</tr>
+									) ) }
+								</tbody>
+							</table>
+						) : (
+							<p>
+								{ __(
+									'No scheduled imports yet.',
+									'ai-importer'
+								) }
+							</p>
+						) }
+
+						<hr />
+
+						<h3>{ __( 'Add a schedule', 'ai-importer' ) }</h3>
+
+						{ connectedSources.length === 0 ? (
+							<p>
+								{ __(
+									'Connect a source to enable scheduled imports.',
+									'ai-importer'
+								) }
+							</p>
+						) : (
+							<Flex
+								align="flex-end"
+								gap={ 4 }
+								justify="flex-start"
+								wrap
+							>
+								<FlexItem>
+									<SelectControl
+										__nextHasNoMarginBottom
+										label={ __( 'Source', 'ai-importer' ) }
+										value={ sourceAdapter }
+										options={ connectedSources.map(
+											( source ) => ( {
+												label: source.name,
+												value: source.id,
+											} )
+										) }
+										onChange={ setSourceAdapter }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<SelectControl
+										__nextHasNoMarginBottom
+										label={ __(
+											'Interval',
+											'ai-importer'
+										) }
+										value={ interval }
+										options={ INTERVAL_OPTIONS }
+										onChange={ setInterval }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<CheckboxControl
+										__nextHasNoMarginBottom
+										label={ __(
+											'Update existing items',
+											'ai-importer'
+										) }
+										checked={ updateExisting }
+										onChange={ setUpdateExisting }
+									/>
+								</FlexItem>
+								<FlexItem>
+									<Button
+										variant="primary"
+										onClick={ handleAdd }
+										isBusy={ saving }
+										disabled={ saving || ! sourceAdapter }
+									>
+										{ __( 'Add schedule', 'ai-importer' ) }
+									</Button>
+								</FlexItem>
+							</Flex>
+						) }
+					</>
+				) }
+			</CardBody>
+		</Card>
+	);
+}

--- a/src/pages/Settings.js
+++ b/src/pages/Settings.js
@@ -14,6 +14,7 @@ import {
 	CardHeader,
 	ExternalLink,
 } from '@wordpress/components';
+import ScheduledImports from '../components/ScheduledImports';
 
 /**
  * Settings page component.
@@ -52,6 +53,8 @@ export default function Settings() {
 					</p>
 				</CardBody>
 			</Card>
+
+			<ScheduledImports />
 		</div>
 	);
 }

--- a/tests/Unit/Processor/ImportSchedulerTest.php
+++ b/tests/Unit/Processor/ImportSchedulerTest.php
@@ -1,0 +1,459 @@
+<?php
+/**
+ * ImportScheduler tests.
+ *
+ * @package AI_Importer\Tests\Unit\Processor
+ */
+
+namespace AI_Importer\Tests\Unit\Processor;
+
+use AI_Importer\Adapters\AdapterInterface;
+use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Adapters\Manifest\ContentManifest;
+use AI_Importer\Adapters\Manifest\ContentType;
+use AI_Importer\Adapters\Manifest\ManifestItem;
+use AI_Importer\Processor\ImportScheduler;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Actions;
+use Brain\Monkey\Functions;
+use DateTimeImmutable;
+use Mockery;
+
+/**
+ * Tests for the ImportScheduler class.
+ */
+class ImportSchedulerTest extends TestCase {
+
+	/**
+	 * In-memory options store.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $options;
+
+	/**
+	 * Whether a recurring action was scheduled.
+	 *
+	 * @var bool
+	 */
+	private bool $recurring_scheduled;
+
+	/**
+	 * Whether an action was unscheduled.
+	 *
+	 * @var bool
+	 */
+	private bool $action_unscheduled;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		AdapterRegistry::get_instance()->reset();
+		$this->options             = array();
+		$this->recurring_scheduled = false;
+		$this->action_unscheduled  = false;
+
+		$options     = &$this->options;
+		$scheduled   = &$this->recurring_scheduled;
+		$unscheduled = &$this->action_unscheduled;
+
+		Functions\when( 'get_option' )->alias(
+			function ( $key, $default = false ) use ( &$options ) {
+				return $options[ $key ] ?? $default;
+			}
+		);
+
+		Functions\when( 'update_option' )->alias(
+			function ( $key, $value ) use ( &$options ) {
+				$options[ $key ] = $value;
+				return true;
+			}
+		);
+
+		Functions\when( 'sanitize_text_field' )->alias(
+			fn( $value ) => trim( (string) $value )
+		);
+		Functions\when( 'sanitize_key' )->alias(
+			fn( $value ) => preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) )
+		);
+
+		$counter = 0;
+		Functions\when( 'wp_generate_uuid4' )->alias(
+			function () use ( &$counter ) {
+				++$counter;
+				return "schedule-uuid-{$counter}";
+			}
+		);
+
+		Functions\when( 'as_schedule_recurring_action' )->alias(
+			function () use ( &$scheduled ) {
+				$scheduled = true;
+				return 1;
+			}
+		);
+		Functions\when( 'as_unschedule_action' )->alias(
+			function () use ( &$unscheduled ) {
+				$unscheduled = true;
+			}
+		);
+		Functions\when( 'as_next_scheduled_action' )->justReturn( 1893456000 );
+	}
+
+	/**
+	 * Test init registers the recurring hook handler.
+	 *
+	 * @return void
+	 */
+	public function test_init_registers_hook(): void {
+		Actions\expectAdded( ImportScheduler::HOOK_NAME );
+
+		$scheduler = new ImportScheduler();
+		$scheduler->init();
+
+		$this->assertBrainMonkeyExpectations();
+	}
+
+	/**
+	 * Test saving a schedule registers a recurring action and stores it.
+	 *
+	 * @return void
+	 */
+	public function test_save_schedule_registers_recurring_action(): void {
+		$scheduler = new ImportScheduler();
+
+		$schedule = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+				'enabled'        => true,
+			)
+		);
+
+		$this->assertTrue( $this->recurring_scheduled );
+		$this->assertSame( 'twitter', $schedule['source_adapter'] );
+		$this->assertSame( 'daily', $schedule['interval'] );
+		$this->assertTrue( $schedule['enabled'] );
+		$this->assertNotEmpty( $schedule['id'] );
+
+		// Stored in the option.
+		$this->assertCount( 1, $this->options[ ImportScheduler::OPTION_KEY ] );
+	}
+
+	/**
+	 * Test a disabled schedule does not register a recurring action.
+	 *
+	 * @return void
+	 */
+	public function test_save_disabled_schedule_does_not_schedule(): void {
+		$scheduler = new ImportScheduler();
+
+		$scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+				'enabled'        => false,
+			)
+		);
+
+		$this->assertFalse( $this->recurring_scheduled );
+		// The action is still cleared first (to remove any prior schedule).
+		$this->assertTrue( $this->action_unscheduled );
+	}
+
+	/**
+	 * Test updating an existing schedule replaces it in place.
+	 *
+	 * @return void
+	 */
+	public function test_save_schedule_updates_existing(): void {
+		$scheduler = new ImportScheduler();
+
+		$created = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$updated = $scheduler->save_schedule(
+			array(
+				'id'             => $created['id'],
+				'source_adapter' => 'twitter',
+				'interval'       => 'weekly',
+			)
+		);
+
+		$this->assertSame( $created['id'], $updated['id'] );
+		$this->assertSame( 'weekly', $updated['interval'] );
+		$this->assertCount( 1, $this->options[ ImportScheduler::OPTION_KEY ] );
+	}
+
+	/**
+	 * Test deleting a schedule unschedules its action and removes it.
+	 *
+	 * @return void
+	 */
+	public function test_delete_schedule_unschedules_action(): void {
+		$scheduler = new ImportScheduler();
+
+		$schedule = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$this->action_unscheduled = false;
+
+		$result = $scheduler->delete_schedule( $schedule['id'] );
+
+		$this->assertTrue( $result );
+		$this->assertTrue( $this->action_unscheduled );
+		$this->assertSame( array(), $this->options[ ImportScheduler::OPTION_KEY ] );
+	}
+
+	/**
+	 * Test deleting an unknown schedule returns false.
+	 *
+	 * @return void
+	 */
+	public function test_delete_unknown_schedule_returns_false(): void {
+		$scheduler = new ImportScheduler();
+
+		$this->assertFalse( $scheduler->delete_schedule( 'does-not-exist' ) );
+	}
+
+	/**
+	 * Test running a schedule for a connected source creates a batch.
+	 *
+	 * @return void
+	 */
+	public function test_run_schedule_creates_batch_for_connected_source(): void {
+		$this->register_mock_adapter( 'twitter', true, array( 'tweet-1', 'tweet-2' ) );
+
+		$created_batch = null;
+		Actions\expectDone( 'ai_importer_batch_created' )
+			->once()
+			->whenHappen(
+				function ( $batch_id, $batch ) use ( &$created_batch ) {
+					$created_batch = $batch;
+				}
+			);
+
+		$scheduler = new ImportScheduler();
+		$schedule  = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$scheduler->run_schedule( $schedule['id'] );
+
+		$this->assertNotNull( $created_batch );
+		$this->assertSame( 'twitter', $created_batch['source_adapter'] );
+		$this->assertTrue( $created_batch['update_existing'] );
+		$this->assertSame( 'processing', $created_batch['state'] );
+		$this->assertSame( array( 'tweet-1', 'tweet-2' ), $created_batch['item_ids'] );
+		$this->assertTrue( $created_batch['scheduled'] );
+
+		// last_run recorded.
+		$stored = $this->options[ ImportScheduler::OPTION_KEY ][0];
+		$this->assertNotNull( $stored['last_run'] );
+	}
+
+	/**
+	 * Test running a schedule reuses the source's saved mapping.
+	 *
+	 * @return void
+	 */
+	public function test_run_schedule_reuses_saved_mapping(): void {
+		$this->register_mock_adapter( 'twitter', true, array( 'tweet-1' ) );
+
+		$this->options['ai_importer_mappings_twitter'] = array(
+			'post_type'   => 'post',
+			'post_status' => 'publish',
+		);
+
+		$created_batch = null;
+		Actions\expectDone( 'ai_importer_batch_created' )
+			->whenHappen(
+				function ( $batch_id, $batch ) use ( &$created_batch ) {
+					$created_batch = $batch;
+				}
+			);
+
+		$scheduler = new ImportScheduler();
+		$schedule  = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$scheduler->run_schedule( $schedule['id'] );
+
+		$this->assertSame(
+			array(
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+			),
+			$created_batch['mapping']
+		);
+	}
+
+	/**
+	 * Test a disconnected source is skipped without creating a batch.
+	 *
+	 * @return void
+	 */
+	public function test_run_schedule_skips_disconnected_source(): void {
+		$this->register_mock_adapter( 'twitter', false, array( 'tweet-1' ) );
+
+		Actions\expectDone( 'ai_importer_batch_created' )->never();
+
+		$scheduler = new ImportScheduler();
+		$schedule  = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$scheduler->run_schedule( $schedule['id'] );
+
+		// No batch index created.
+		$this->assertArrayNotHasKey( 'ai_importer_batch_index', $this->options );
+	}
+
+	/**
+	 * Test a missing adapter is skipped gracefully.
+	 *
+	 * @return void
+	 */
+	public function test_run_schedule_skips_unknown_adapter(): void {
+		Actions\expectDone( 'ai_importer_batch_created' )->never();
+
+		$scheduler = new ImportScheduler();
+		$schedule  = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'nonexistent',
+				'interval'       => 'daily',
+			)
+		);
+
+		$scheduler->run_schedule( $schedule['id'] );
+
+		$this->assertArrayNotHasKey( 'ai_importer_batch_index', $this->options );
+	}
+
+	/**
+	 * Test an overlapping run is skipped when a batch is already processing.
+	 *
+	 * @return void
+	 */
+	public function test_run_schedule_skips_when_batch_processing(): void {
+		$this->register_mock_adapter( 'twitter', true, array( 'tweet-1' ) );
+
+		// Existing processing batch for the same source.
+		$this->options['ai_importer_batch_index']             = array( 'existing-batch' );
+		$this->options['ai_importer_batch_existing-batch']    = array(
+			'id'             => 'existing-batch',
+			'source_adapter' => 'twitter',
+			'state'          => 'processing',
+		);
+
+		Actions\expectDone( 'ai_importer_batch_created' )->never();
+
+		$scheduler = new ImportScheduler();
+		$schedule  = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$scheduler->run_schedule( $schedule['id'] );
+
+		// Index unchanged (no new batch added).
+		$this->assertSame( array( 'existing-batch' ), $this->options['ai_importer_batch_index'] );
+	}
+
+	/**
+	 * Test a disabled schedule does not run even when fired.
+	 *
+	 * @return void
+	 */
+	public function test_run_schedule_skips_disabled_schedule(): void {
+		$this->register_mock_adapter( 'twitter', true, array( 'tweet-1' ) );
+
+		Actions\expectDone( 'ai_importer_batch_created' )->never();
+
+		$scheduler = new ImportScheduler();
+		$schedule  = $scheduler->save_schedule(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+				'enabled'        => false,
+			)
+		);
+
+		$scheduler->run_schedule( $schedule['id'] );
+
+		$this->assertArrayNotHasKey( 'ai_importer_batch_index', $this->options );
+	}
+
+	/**
+	 * Test running an unknown schedule ID does nothing.
+	 *
+	 * @return void
+	 */
+	public function test_run_unknown_schedule_does_nothing(): void {
+		Actions\expectDone( 'ai_importer_batch_created' )->never();
+
+		$scheduler = new ImportScheduler();
+		$scheduler->run_schedule( 'missing-schedule' );
+
+		$this->assertArrayNotHasKey( 'ai_importer_batch_index', $this->options );
+	}
+
+	/**
+	 * Register a mock adapter that returns a manifest with the given items.
+	 *
+	 * @param string             $id              Adapter ID.
+	 * @param bool               $is_authenticated Whether authenticated.
+	 * @param array<int, string> $item_ids        Manifest item IDs.
+	 * @return void
+	 */
+	private function register_mock_adapter( string $id, bool $is_authenticated, array $item_ids ): void {
+		$manifest = new ContentManifest( $id );
+
+		foreach ( $item_ids as $item_id ) {
+			$manifest->add_item(
+				new ManifestItem(
+					id: $item_id,
+					type: ContentType::POST,
+					title: 'Item ' . $item_id,
+					created_at: new DateTimeImmutable( '2024-01-15' ),
+				)
+			);
+		}
+
+		$adapter = Mockery::mock( AdapterInterface::class );
+		$adapter->shouldReceive( 'get_id' )->andReturn( $id );
+		$adapter->shouldReceive( 'get_name' )->andReturn( ucfirst( $id ) );
+		$adapter->shouldReceive( 'get_description' )->andReturn( "The {$id} adapter." );
+		$adapter->shouldReceive( 'get_icon' )->andReturn( "dashicons-{$id}" );
+		$adapter->shouldReceive( 'get_auth_type' )->andReturn( 'file_upload' );
+		$adapter->shouldReceive( 'is_authenticated' )->andReturn( $is_authenticated );
+		$adapter->shouldReceive( 'get_supported_content_types' )->andReturn( array( 'post' ) );
+		$adapter->shouldReceive( 'fetch_manifest' )->andReturn( $manifest );
+
+		AdapterRegistry::get_instance()->register( $adapter );
+	}
+}

--- a/tests/Unit/REST/SchedulesControllerTest.php
+++ b/tests/Unit/REST/SchedulesControllerTest.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * SchedulesController tests.
+ *
+ * @package AI_Importer\Tests\Unit\REST
+ */
+
+namespace AI_Importer\Tests\Unit\REST;
+
+use AI_Importer\Adapters\AdapterInterface;
+use AI_Importer\Adapters\AdapterRegistry;
+use AI_Importer\Processor\ImportScheduler;
+use AI_Importer\REST\SchedulesController;
+use AI_Importer\Tests\Unit\TestCase;
+use Brain\Monkey\Functions;
+use Mockery;
+use WP_REST_Request;
+
+/**
+ * Tests for the SchedulesController class.
+ */
+class SchedulesControllerTest extends TestCase {
+
+	/**
+	 * Controller instance.
+	 *
+	 * @var SchedulesController
+	 */
+	private SchedulesController $controller;
+
+	/**
+	 * In-memory option store.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private array $options;
+
+	/**
+	 * Set up each test.
+	 *
+	 * @return void
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		AdapterRegistry::get_instance()->reset();
+		$this->options = array();
+
+		Functions\when( 'current_user_can' )->justReturn( true );
+		Functions\when( 'rest_ensure_response' )->alias(
+			function ( $data ) {
+				if ( $data instanceof \WP_REST_Response ) {
+					return $data;
+				}
+				return new \WP_REST_Response( $data );
+			}
+		);
+		Functions\when( 'sanitize_text_field' )->alias(
+			fn( $value ) => trim( (string) $value )
+		);
+		Functions\when( 'sanitize_key' )->alias(
+			fn( $value ) => preg_replace( '/[^a-z0-9_\-]/', '', strtolower( (string) $value ) )
+		);
+
+		$counter = 0;
+		Functions\when( 'wp_generate_uuid4' )->alias(
+			function () use ( &$counter ) {
+				++$counter;
+				return "schedule-uuid-{$counter}";
+			}
+		);
+
+		$options = &$this->options;
+		Functions\when( 'get_option' )->alias(
+			function ( $key, $default = false ) use ( &$options ) {
+				return $options[ $key ] ?? $default;
+			}
+		);
+		Functions\when( 'update_option' )->alias(
+			function ( $key, $value ) use ( &$options ) {
+				$options[ $key ] = $value;
+				return true;
+			}
+		);
+
+		// Action Scheduler shims.
+		Functions\when( 'as_schedule_recurring_action' )->justReturn( 1 );
+		Functions\when( 'as_unschedule_action' )->justReturn( null );
+		Functions\when( 'as_next_scheduled_action' )->justReturn( 1893456000 );
+
+		$this->controller = new SchedulesController();
+	}
+
+	/**
+	 * Test get_items returns an empty list initially.
+	 *
+	 * @return void
+	 */
+	public function test_get_items_empty(): void {
+		$request  = new WP_REST_Request( 'GET', '/ai-importer/v1/schedules' );
+		$response = $this->controller->get_items( $request );
+
+		$this->assertSame( array(), $response->get_data() );
+	}
+
+	/**
+	 * Test create_item creates a schedule.
+	 *
+	 * @return void
+	 */
+	public function test_create_item(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$request->set_body_params(
+			array(
+				'source_adapter'  => 'twitter',
+				'interval'        => 'daily',
+				'update_existing' => true,
+				'enabled'         => true,
+			)
+		);
+
+		$response = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertSame( 201, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertSame( 'twitter', $data['source_adapter'] );
+		$this->assertSame( 'daily', $data['interval'] );
+		$this->assertTrue( $data['enabled'] );
+		$this->assertNotEmpty( $data['id'] );
+
+		$this->assertCount( 1, $this->options[ ImportScheduler::OPTION_KEY ] );
+	}
+
+	/**
+	 * Test create_item rejects an unknown adapter.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_invalid_source(): void {
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'nonexistent',
+				'interval'       => 'daily',
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_source', $result->get_error_codes()[0] );
+	}
+
+	/**
+	 * Test create_item rejects an invalid interval.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_invalid_interval(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$request->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'yearly',
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'invalid_interval', $result->get_error_codes()[0] );
+	}
+
+	/**
+	 * Test create_item updates an existing schedule when an ID is supplied.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_updates_existing(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$create = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$create->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+		$created = $this->controller->create_item( $create )->get_data();
+
+		$update = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$update->set_body_params(
+			array(
+				'id'             => $created['id'],
+				'source_adapter' => 'twitter',
+				'interval'       => 'weekly',
+			)
+		);
+		$updated = $this->controller->create_item( $update )->get_data();
+
+		$this->assertSame( $created['id'], $updated['id'] );
+		$this->assertSame( 'weekly', $updated['interval'] );
+		$this->assertCount( 1, $this->options[ ImportScheduler::OPTION_KEY ] );
+	}
+
+	/**
+	 * Test create_item rejects updating a non-existent schedule.
+	 *
+	 * @return void
+	 */
+	public function test_create_item_update_unknown_schedule(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$request = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$request->set_body_params(
+			array(
+				'id'             => 'does-not-exist',
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+
+		$result = $this->controller->create_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'schedule_not_found', $result->get_error_codes()[0] );
+	}
+
+	/**
+	 * Test delete_item removes a schedule.
+	 *
+	 * @return void
+	 */
+	public function test_delete_item(): void {
+		$this->register_mock_adapter( 'twitter' );
+
+		$create = new WP_REST_Request( 'POST', '/ai-importer/v1/schedules' );
+		$create->set_body_params(
+			array(
+				'source_adapter' => 'twitter',
+				'interval'       => 'daily',
+			)
+		);
+		$created = $this->controller->create_item( $create )->get_data();
+
+		$request       = new WP_REST_Request( 'DELETE', '/ai-importer/v1/schedules/' . $created['id'] );
+		$request['id'] = $created['id'];
+		$response      = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( \WP_REST_Response::class, $response );
+		$this->assertTrue( $response->get_data()['deleted'] );
+		$this->assertSame( array(), $this->options[ ImportScheduler::OPTION_KEY ] );
+	}
+
+	/**
+	 * Test delete_item returns an error for an unknown schedule.
+	 *
+	 * @return void
+	 */
+	public function test_delete_item_not_found(): void {
+		$request       = new WP_REST_Request( 'DELETE', '/ai-importer/v1/schedules/missing' );
+		$request['id'] = 'missing';
+		$result        = $this->controller->delete_item( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'schedule_not_found', $result->get_error_codes()[0] );
+	}
+
+	/**
+	 * Test permissions check denies unauthorized users.
+	 *
+	 * @return void
+	 */
+	public function test_permissions_check_denies_unauthorized(): void {
+		Functions\when( 'current_user_can' )->justReturn( false );
+
+		$request = new WP_REST_Request( 'GET', '/ai-importer/v1/schedules' );
+		$result  = $this->controller->permissions_check( $request );
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+	}
+
+	/**
+	 * Register a mock adapter in the registry.
+	 *
+	 * @param string $id Adapter ID.
+	 * @return void
+	 */
+	private function register_mock_adapter( string $id ): void {
+		$adapter = Mockery::mock( AdapterInterface::class );
+		$adapter->shouldReceive( 'get_id' )->andReturn( $id );
+		$adapter->shouldReceive( 'get_name' )->andReturn( ucfirst( $id ) );
+		$adapter->shouldReceive( 'get_description' )->andReturn( "The {$id} adapter." );
+		$adapter->shouldReceive( 'get_icon' )->andReturn( "dashicons-{$id}" );
+		$adapter->shouldReceive( 'get_auth_type' )->andReturn( 'file_upload' );
+		$adapter->shouldReceive( 'is_authenticated' )->andReturn( true );
+		$adapter->shouldReceive( 'get_supported_content_types' )->andReturn( array( 'post' ) );
+
+		AdapterRegistry::get_instance()->register( $adapter );
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', '/tmp/wordpress/' );
 }
 
+// WordPress time constants (used by ImportScheduler intervals).
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
+	define( 'HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+	define( 'DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS );
+}
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+	define( 'WEEK_IN_SECONDS', 7 * DAY_IN_SECONDS );
+}
+
 /**
  * Stub WP_Error class for testing.
  */


### PR DESCRIPTION
## Summary

Implements scheduled imports (PRD F10.3): connected sources can be polled automatically on a recurring interval, importing only new content.

### Behavior

- **`ImportScheduler`** (`includes/Processor/ImportScheduler.php`) stores schedules in the `ai_importer_schedules` option as `{id, source_adapter, interval, update_existing, enabled, last_run, next_run}` and registers a recurring Action Scheduler action (`as_schedule_recurring_action`) per enabled schedule.
- When a schedule fires, the scheduler:
  - Resolves and validates the source; a disconnected/unauthenticated or unknown source is logged and skipped (the scheduler never crashes).
  - Guards against overlapping runs - skips if a batch for that source is already `processing`/`paused`.
  - Fetches the adapter manifest, builds the `item_ids` list, and creates an import batch through the existing `ai_importer_batch_created` path with `update_existing = true`, so the F10.2 duplicate detection means only NEW items are imported.
  - Reuses the source's saved mapping (`ai_importer_mappings_{adapter}`) when present.
  - Records `last_run`/`next_run`.
- Created/updating a schedule re-registers its recurring action; deleting unschedules it (`as_unschedule_action`).

### REST

`SchedulesController` adds (all `manage_options`, schema-validated):
- `GET /ai-importer/v1/schedules` - list
- `POST /ai-importer/v1/schedules` - create/update (interval enum hourly/daily/weekly; source validated against the registry; booleans sanitized)
- `DELETE /ai-importer/v1/schedules/{id}` - delete

### Frontend

A "Scheduled Imports" section on the Settings page lists schedules (source, interval, enable toggle, last/next run) and provides a form to add a schedule from connected sources, with an enable/disable toggle and delete. Built with `@wordpress/components` and accessible labels.

### Plugin wiring

`ImportScheduler` is booted next to `ImportProcessor` in `Plugin.php`; the controller is registered in the REST init callback.

## Testing

- `./vendor/bin/phpunit` - 617 tests pass (22 new: `ImportSchedulerTest`, `SchedulesControllerTest`)
- `composer run lint` (phpcs) - clean
- `composer run phpstan` - no errors
- `npm run build` - succeeds
- `npm run lint:js` - clean

Part of #18 (https://github.com/adamsilverstein/ai-importer/issues/18)