### PR TITLE
Mark compatible with WordPress 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: adamsilverstein
 Tags: import, migration, social media, twitter, instagram, medium, ai
 Requires at least: 7.0
-Tested up to: 7.0
+Tested up to: 7.1
 Requires PHP: 8.1
 Stable tag: 0.1.0
 License: GPLv2 or later


### PR DESCRIPTION
_Claude did the digging here, findings below:_

Bumps `Tested up to` to 7.1 ahead of tomorrow's release. Readme only &mdash; this plugin is not in the plugin directory, so no version bump or release is needed.

**Opened as a draft**, because testing against 7.1-RC3 turned up something that should probably be settled before this is merged.

### The plugin is inert on WordPress 7.1

`check_dependencies()` in `ai-importer.php` gates the entire plugin on `wp_get_ai_client()`:

```php
// WordPress 7.0+ includes native AI capabilities via wp_get_ai_client().
if ( ! function_exists( 'wp_get_ai_client' ) ) {
```

That function does not exist in WordPress 7.1-RC3. What core ships is `wp_ai_client_prompt()`. Confirmed on a stock 7.1-RC3 install with no plugins active:

```
wp_get_ai_client:    MISSING
wp_ai_client_prompt: EXISTS
```

Activating the `ai` feature plugin alongside it does not provide `wp_get_ai_client()` either.

The consequences, all reproduced:

1. The dependency check always fails, so `Plugin::init()` never runs, the admin menu is never registered, and `/wp-admin/admin.php?page=ai-importer` returns **403**.
2. The failure path builds its message with `__( ..., 'ai-importer' )` at plugin-load time, which trips a `_load_textdomain_just_in_time` notice on every request:

```
PHP Notice: Function _load_textdomain_just_in_time was called incorrectly.
Translation loading for the ai-importer domain was triggered too early.
```

`AIService` calls `wp_get_ai_client()` directly as well, so the fix is more than renaming the guard &mdash; it is a call over the AI layer, which is why it is not attempted here.

### Testing

Verified against WordPress 7.1-RC3 in wp-env on PHP 8.3, with `WP_DEBUG` on and this plugin the only one active:

- Dashboard and the front end load with no JavaScript console or page errors.
- The plugin's own admin page returns 403, and `debug.log` fills with the textdomain notice above.
- `composer test` &mdash; 682 tests, 1620 assertions, all passing. The unit tests stub `wp_get_ai_client()`, which is why they stayed green while the real integration broke.

Marking this one "tested up to 7.1" while it does nothing on 7.1 seems worth a second opinion, hence the draft.

## AI Use

Description written with 🤖 Claude Code.
